### PR TITLE
Culture and religion loaders

### DIFF
--- a/EU4toV3/EU4ToV3.vcxproj
+++ b/EU4toV3/EU4ToV3.vcxproj
@@ -312,6 +312,9 @@
     <ClCompile Include="..\commonItems\targa.cpp" />
     <ClCompile Include="Source\Configuration\Configuration.cpp" />
     <ClCompile Include="Source\EU4toVic3Converter.cpp" />
+    <ClCompile Include="Source\EU4World\CultureLoader\CultureParser.cpp" />
+    <ClCompile Include="Source\EU4World\CultureLoader\CultureGroupParser.cpp" />
+    <ClCompile Include="Source\EU4World\CultureLoader\CultureLoader.cpp" />
     <ClCompile Include="Source\EU4World\Mods\ModParser.cpp" />
     <ClCompile Include="Source\EU4World\Mods\ModNames.cpp" />
     <ClCompile Include="Source\EU4World\Mods\ModLoader.cpp" />
@@ -319,6 +322,8 @@
     <ClCompile Include="Source\EU4World\RegionManager\Region.cpp" />
     <ClCompile Include="Source\EU4World\RegionManager\RegionManager.cpp" />
     <ClCompile Include="Source\EU4World\RegionManager\SuperRegion.cpp" />
+    <ClCompile Include="Source\EU4World\ReligionLoader\ReligionParser.cpp" />
+    <ClCompile Include="Source\EU4World\ReligionLoader\ReligionLoader.cpp" />
     <ClCompile Include="Source\EU4World\World.cpp" />
     <ClCompile Include="Source\main.cpp" />
     <ClCompile Include="Source\Mappers\ConverterVersion\ConverterVersion.cpp" />
@@ -342,6 +347,9 @@
     <ClInclude Include="..\commonItems\targa.h" />
     <ClInclude Include="Source\Configuration\Configuration.h" />
     <ClInclude Include="Source\EU4ToVic3Converter.h" />
+    <ClInclude Include="Source\EU4World\CultureLoader\CultureParser.h" />
+    <ClInclude Include="Source\EU4World\CultureLoader\CultureGroupParser.h" />
+    <ClInclude Include="Source\EU4World\CultureLoader\CultureLoader.h" />
     <ClInclude Include="Source\EU4World\Mods\ModParser.h" />
     <ClInclude Include="Source\EU4World\Mods\ModNames.h" />
     <ClInclude Include="Source\EU4World\Mods\ModLoader.h" />
@@ -349,6 +357,8 @@
     <ClInclude Include="Source\EU4World\RegionManager\Region.h" />
     <ClInclude Include="Source\EU4World\RegionManager\RegionManager.h" />
     <ClInclude Include="Source\EU4World\RegionManager\SuperRegion.h" />
+    <ClInclude Include="Source\EU4World\ReligionLoader\ReligionParser.h" />
+    <ClInclude Include="Source\EU4World\ReligionLoader\ReligionLoader.h" />
     <ClInclude Include="Source\EU4World\World.h" />
     <ClInclude Include="Source\Helpers\rakaly.h" />
     <ClInclude Include="Source\Helpers\rakaly_wrapper.h" />

--- a/EU4toV3/EU4ToV3.vcxproj.filters
+++ b/EU4toV3/EU4ToV3.vcxproj.filters
@@ -81,6 +81,21 @@
     <ClCompile Include="Source\EU4World\RegionManager\SuperRegion.cpp">
       <Filter>EU4World\RegionManager</Filter>
     </ClCompile>
+    <ClCompile Include="Source\EU4World\ReligionLoader\ReligionParser.cpp">
+      <Filter>EU4World\ReligionLoader</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\EU4World\ReligionLoader\ReligionLoader.cpp">
+      <Filter>EU4World\ReligionLoader</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\EU4World\CultureLoader\CultureParser.cpp">
+      <Filter>EU4World\CultureLoader</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\EU4World\CultureLoader\CultureGroupParser.cpp">
+      <Filter>EU4World\CultureLoader</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\EU4World\CultureLoader\CultureLoader.cpp">
+      <Filter>EU4World\CultureLoader</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\EU4ToVic3Converter.h" />
@@ -168,6 +183,21 @@
     <ClInclude Include="Source\EU4World\RegionManager\SuperRegion.h">
       <Filter>EU4World\RegionManager</Filter>
     </ClInclude>
+    <ClInclude Include="Source\EU4World\ReligionLoader\ReligionParser.h">
+      <Filter>EU4World\ReligionLoader</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\EU4World\ReligionLoader\ReligionLoader.h">
+      <Filter>EU4World\ReligionLoader</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\EU4World\CultureLoader\CultureParser.h">
+      <Filter>EU4World\CultureLoader</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\EU4World\CultureLoader\CultureGroupParser.h">
+      <Filter>EU4World\CultureLoader</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\EU4World\CultureLoader\CultureLoader.h">
+      <Filter>EU4World\CultureLoader</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="EU4World">
@@ -199,6 +229,12 @@
     </Filter>
     <Filter Include="EU4World\RegionManager">
       <UniqueIdentifier>{e2723ebd-a078-4524-bff0-9457b5f9f27e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="EU4World\ReligionLoader">
+      <UniqueIdentifier>{dba84e8d-44a6-4c86-b579-f305819495b2}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="EU4World\CultureLoader">
+      <UniqueIdentifier>{dd81ecfb-7296-491f-b7a5-2f12b9b48578}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/EU4toV3/Source/EU4World/CultureLoader/CultureGroupParser.cpp
+++ b/EU4toV3/Source/EU4World/CultureLoader/CultureGroupParser.cpp
@@ -1,0 +1,61 @@
+#include "CultureGroupParser.h"
+#include "CommonRegexes.h"
+#include "ParserHelpers.h"
+#include <ranges>
+
+EU4::CultureGroupParser::CultureGroupParser(std::string theName, std::istream& theStream): cultureGroupName(std::move(theName))
+{
+	registerKeys();
+	parseStream(theStream);
+	clearRegisteredKeywords();
+
+	if (!maleNames.empty())
+		for (auto& culture: cultures | std::views::values)
+			culture.addMaleNames(maleNames);
+
+	if (!femaleNames.empty())
+		for (auto& culture: cultures | std::views::values)
+			culture.addFemaleNames(femaleNames);
+
+	if (!dynastyNames.empty())
+		for (auto& culture: cultures | std::views::values)
+			culture.addDynastyNames(dynastyNames);
+}
+
+void EU4::CultureGroupParser::registerKeys()
+{
+	registerRegex("second_graphical_culture|graphical_culture", [this](const std::string& unused, std::istream& theStream) {
+		commonItems::ignoreItem(unused, theStream);
+	});
+	registerKeyword("male_names", [this](std::istream& theStream) {
+		maleNames = commonItems::getStrings(theStream);
+	});
+	registerKeyword("female_names", [this](std::istream& theStream) {
+		femaleNames = commonItems::getStrings(theStream);
+	});
+	registerKeyword("dynasty_names", [this](std::istream& theStream) {
+		dynastyNames = commonItems::getStrings(theStream);
+	});
+	registerRegex(R"([\w_]+)", [this](std::string cultureName, std::istream& theStream) {
+		auto newCulture = CultureParser(theStream);
+		cultures.insert(std::make_pair(cultureName, newCulture));
+	});
+	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
+}
+
+void EU4::CultureGroupParser::mergeCulture(const std::string& cultureName, const CultureParser& cultureParser)
+{
+	const auto& cultureItr = cultures.find(cultureName);
+	if (cultureItr != cultures.end())
+	{
+		cultureItr->second.addMaleNames(cultureParser.getMaleNames());
+		cultureItr->second.addFemaleNames(cultureParser.getFemaleNames());
+		cultureItr->second.addDynastyNames(cultureParser.getDynastyNames());
+		if (!cultureParser.getPrimaryTag().empty())
+			cultureItr->second.setPrimaryTag(cultureParser.getPrimaryTag()); // overwriting with modded.
+	}
+	else
+	{
+		cultures.emplace(cultureName, cultureParser);
+	}
+}

--- a/EU4toV3/Source/EU4World/CultureLoader/CultureGroupParser.cpp
+++ b/EU4toV3/Source/EU4World/CultureLoader/CultureGroupParser.cpp
@@ -36,7 +36,7 @@ void EU4::CultureGroupParser::registerKeys()
 	registerKeyword("dynasty_names", [this](std::istream& theStream) {
 		dynastyNames = commonItems::getStrings(theStream);
 	});
-	registerRegex(R"([\w_]+)", [this](std::string cultureName, std::istream& theStream) {
+	registerRegex(commonItems::stringRegex, [this](const std::string& cultureName, std::istream& theStream) {
 		auto newCulture = CultureParser(theStream);
 		cultures.emplace(cultureName, newCulture);
 	});

--- a/EU4toV3/Source/EU4World/CultureLoader/CultureGroupParser.cpp
+++ b/EU4toV3/Source/EU4World/CultureLoader/CultureGroupParser.cpp
@@ -38,7 +38,7 @@ void EU4::CultureGroupParser::registerKeys()
 	});
 	registerRegex(R"([\w_]+)", [this](std::string cultureName, std::istream& theStream) {
 		auto newCulture = CultureParser(theStream);
-		cultures.insert(std::make_pair(cultureName, newCulture));
+		cultures.emplace(cultureName, newCulture);
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
 }

--- a/EU4toV3/Source/EU4World/CultureLoader/CultureGroupParser.h
+++ b/EU4toV3/Source/EU4World/CultureLoader/CultureGroupParser.h
@@ -21,10 +21,11 @@ class CultureGroupParser: commonItems::parser
 	void registerKeys();
 
 	std::string cultureGroupName;
+	std::map<std::string, CultureParser> cultures;
+
 	std::vector<std::string> maleNames;
 	std::vector<std::string> femaleNames;
 	std::vector<std::string> dynastyNames;
-	std::map<std::string, CultureParser> cultures;
 };
 } // namespace EU4
 

--- a/EU4toV3/Source/EU4World/CultureLoader/CultureGroupParser.h
+++ b/EU4toV3/Source/EU4World/CultureLoader/CultureGroupParser.h
@@ -1,0 +1,31 @@
+#ifndef CULTURE_GROUP_PARSER
+#define CULTURE_GROUP_PARSER
+#include "CultureParser.h"
+#include "Parser.h"
+#include <map>
+
+namespace EU4
+{
+class CultureGroupParser: commonItems::parser
+{
+  public:
+	CultureGroupParser() = default;
+	CultureGroupParser(std::string theName, std::istream& theStream);
+
+	[[nodiscard]] const auto& getName() const { return cultureGroupName; }
+	[[nodiscard]] const auto& getCultures() const { return cultures; }
+
+	void mergeCulture(const std::string& cultureName, const CultureParser& cultureParser);
+
+  private:
+	void registerKeys();
+
+	std::string cultureGroupName;
+	std::vector<std::string> maleNames;
+	std::vector<std::string> femaleNames;
+	std::vector<std::string> dynastyNames;
+	std::map<std::string, CultureParser> cultures;
+};
+} // namespace EU4
+
+#endif // CULTURE_GROUP_PARSER

--- a/EU4toV3/Source/EU4World/CultureLoader/CultureLoader.cpp
+++ b/EU4toV3/Source/EU4World/CultureLoader/CultureLoader.cpp
@@ -43,7 +43,7 @@ void EU4::CultureLoader::registerKeys()
 		}
 		else
 		{
-			cultureGroupsMap.insert(std::make_pair(cultureGroupName, newGroup));
+			cultureGroupsMap.emplace(cultureGroupName, newGroup);
 		}
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);

--- a/EU4toV3/Source/EU4World/CultureLoader/CultureLoader.cpp
+++ b/EU4toV3/Source/EU4World/CultureLoader/CultureLoader.cpp
@@ -1,12 +1,12 @@
 #include "CultureLoader.h"
+#include "CommonRegexes.h"
 #include "Log.h"
 #include "OSCompatibilityLayer.h"
 #include "ParserHelpers.h"
-#include "CommonRegexes.h"
 #include <ranges>
 
 void EU4::CultureLoader::loadCultures(const std::string& EU4Path, const Mods& mods)
-{	
+{
 	Log(LogLevel::Info) << "-> Loading Cultures and Culture Groups";
 	registerKeys();
 
@@ -18,7 +18,7 @@ void EU4::CultureLoader::loadCultures(const std::string& EU4Path, const Mods& mo
 			parseFile(modPath + "/common/cultures/" + cultureFile);
 
 	clearRegisteredKeywords();
-	
+
 	Log(LogLevel::Info) << "<> Loaded " << cultureGroupsMap.size() << " culture groups.";
 }
 
@@ -31,7 +31,7 @@ void EU4::CultureLoader::loadCultures(std::istream& theStream)
 
 void EU4::CultureLoader::registerKeys()
 {
-	registerRegex(R"([\w_]+)", [this](std::string cultureGroupName, std::istream& theStream) {
+	registerRegex(commonItems::stringRegex, [this](std::string cultureGroupName, std::istream& theStream) {
 		auto newGroup = CultureGroupParser(cultureGroupName, theStream);
 
 		if (cultureGroupsMap.contains(cultureGroupName))

--- a/EU4toV3/Source/EU4World/CultureLoader/CultureLoader.cpp
+++ b/EU4toV3/Source/EU4World/CultureLoader/CultureLoader.cpp
@@ -1,0 +1,50 @@
+#include "CultureLoader.h"
+#include "Log.h"
+#include "OSCompatibilityLayer.h"
+#include "ParserHelpers.h"
+#include "CommonRegexes.h"
+#include <ranges>
+
+void EU4::CultureLoader::loadCultures(const std::string& EU4Path, const Mods& mods)
+{	
+	Log(LogLevel::Info) << "-> Loading Cultures and Culture Groups";
+	registerKeys();
+
+	for (const auto& cultureFile: commonItems::GetAllFilesInFolder(EU4Path + "/common/cultures/"))
+		parseFile(EU4Path + "/common/cultures/" + cultureFile);
+
+	for (const auto& modPath: mods | std::views::values)
+		for (const auto& cultureFile: commonItems::GetAllFilesInFolder(modPath + "/common/cultures/"))
+			parseFile(modPath + "/common/cultures/" + cultureFile);
+
+	clearRegisteredKeywords();
+	
+	Log(LogLevel::Info) << "<> Loaded " << cultureGroupsMap.size() << " culture groups.";
+}
+
+void EU4::CultureLoader::loadCultures(std::istream& theStream)
+{
+	registerKeys();
+	parseStream(theStream);
+	clearRegisteredKeywords();
+}
+
+void EU4::CultureLoader::registerKeys()
+{
+	registerRegex(R"([\w_]+)", [this](std::string cultureGroupName, std::istream& theStream) {
+		auto newGroup = CultureGroupParser(cultureGroupName, theStream);
+
+		if (cultureGroupsMap.contains(cultureGroupName))
+		{
+			// We would normally override base definitions with incoming modded ones, but CK2 definitions
+			// for example are crap and don't actually list all required cultures, so we have to merge.
+			for (const auto& [cultureName, culture]: newGroup.getCultures())
+				cultureGroupsMap[cultureGroupName].mergeCulture(cultureName, culture);
+		}
+		else
+		{
+			cultureGroupsMap.insert(std::make_pair(cultureGroupName, newGroup));
+		}
+	});
+	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
+}

--- a/EU4toV3/Source/EU4World/CultureLoader/CultureLoader.h
+++ b/EU4toV3/Source/EU4World/CultureLoader/CultureLoader.h
@@ -1,0 +1,26 @@
+#ifndef CULTURE_LOADER
+#define CULTURE_LOADER
+#include "CultureGroupParser.h"
+#include "Mods/ModLoader.h"
+#include "Parser.h"
+
+namespace EU4
+{
+class CultureLoader: commonItems::parser
+{
+  public:
+	CultureLoader() = default;
+
+	void loadCultures(const std::string& EU4Path, const Mods& mods);
+	void loadCultures(std::istream& theStream);
+
+	[[nodiscard]] const auto& getCultureGroupsMap() const { return cultureGroupsMap; }
+
+  private:
+	void registerKeys();
+
+	std::map<std::string, CultureGroupParser> cultureGroupsMap;
+};
+} // namespace EU4
+
+#endif // CULTURE_LOADER

--- a/EU4toV3/Source/EU4World/CultureLoader/CultureParser.cpp
+++ b/EU4toV3/Source/EU4World/CultureLoader/CultureParser.cpp
@@ -1,0 +1,27 @@
+#include "CultureParser.h"
+#include "CommonRegexes.h"
+#include "ParserHelpers.h"
+
+EU4::CultureParser::CultureParser(std::istream& theStream)
+{
+	registerKeys();
+	parseStream(theStream);
+	clearRegisteredKeywords();
+}
+
+void EU4::CultureParser::registerKeys()
+{
+	registerKeyword("primary", [this](std::istream& theStream) {
+		primaryTag = commonItems::getString(theStream);
+	});
+	registerKeyword("male_names", [this](std::istream& theStream) {
+		maleNames = commonItems::getStrings(theStream);
+	});
+	registerKeyword("female_names", [this](std::istream& theStream) {
+		femaleNames = commonItems::getStrings(theStream);
+	});
+	registerKeyword("dynasty_names", [this](std::istream& theStream) {
+		dynastyNames = commonItems::getStrings(theStream);
+	});
+	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
+}

--- a/EU4toV3/Source/EU4World/CultureLoader/CultureParser.h
+++ b/EU4toV3/Source/EU4World/CultureLoader/CultureParser.h
@@ -10,15 +10,15 @@ class CultureParser: commonItems::parser
 	CultureParser() = default;
 	explicit CultureParser(std::istream& theStream);
 
+	[[nodiscard]] const auto& getPrimaryTag() const { return primaryTag; }
 	[[nodiscard]] const auto& getMaleNames() const { return maleNames; }
 	[[nodiscard]] const auto& getFemaleNames() const { return femaleNames; }
 	[[nodiscard]] const auto& getDynastyNames() const { return dynastyNames; }
-	[[nodiscard]] const auto& getPrimaryTag() const { return primaryTag; }
 
+	void setPrimaryTag(const std::string& theTag) { primaryTag = theTag; }
 	void addMaleNames(const std::vector<std::string>& theNames) { maleNames.insert(maleNames.end(), theNames.begin(), theNames.end()); }
 	void addFemaleNames(const std::vector<std::string>& theNames) { femaleNames.insert(femaleNames.end(), theNames.begin(), theNames.end()); }
 	void addDynastyNames(const std::vector<std::string>& theNames) { dynastyNames.insert(dynastyNames.end(), theNames.begin(), theNames.end()); }
-	void setPrimaryTag(const std::string& theTag) { primaryTag = theTag; }
 
   private:
 	void registerKeys();

--- a/EU4toV3/Source/EU4World/CultureLoader/CultureParser.h
+++ b/EU4toV3/Source/EU4World/CultureLoader/CultureParser.h
@@ -1,0 +1,33 @@
+#ifndef CULTURE_PARSER
+#define CULTURE_PARSER
+#include "Parser.h"
+
+namespace EU4
+{
+class CultureParser: commonItems::parser
+{
+  public:
+	CultureParser() = default;
+	explicit CultureParser(std::istream& theStream);
+
+	[[nodiscard]] const auto& getMaleNames() const { return maleNames; }
+	[[nodiscard]] const auto& getFemaleNames() const { return femaleNames; }
+	[[nodiscard]] const auto& getDynastyNames() const { return dynastyNames; }
+	[[nodiscard]] const auto& getPrimaryTag() const { return primaryTag; }
+
+	void addMaleNames(const std::vector<std::string>& theNames) { maleNames.insert(maleNames.end(), theNames.begin(), theNames.end()); }
+	void addFemaleNames(const std::vector<std::string>& theNames) { femaleNames.insert(femaleNames.end(), theNames.begin(), theNames.end()); }
+	void addDynastyNames(const std::vector<std::string>& theNames) { dynastyNames.insert(dynastyNames.end(), theNames.begin(), theNames.end()); }
+	void setPrimaryTag(const std::string& theTag) { primaryTag = theTag; }
+
+  private:
+	void registerKeys();
+
+	std::string primaryTag;
+	std::vector<std::string> maleNames;
+	std::vector<std::string> femaleNames;
+	std::vector<std::string> dynastyNames;
+};
+} // namespace EU4
+
+#endif // CULTURE_PARSER

--- a/EU4toV3/Source/EU4World/ReligionLoader/ReligionLoader.cpp
+++ b/EU4toV3/Source/EU4World/ReligionLoader/ReligionLoader.cpp
@@ -1,0 +1,40 @@
+#include "ReligionLoader.h"
+#include "Log.h"
+#include "OSCompatibilityLayer.h"
+#include "ParserHelpers.h"
+#include "ReligionParser.h"
+#include "CommonRegexes.h"
+#include <ranges>
+
+void EU4::ReligionLoader::loadReligions(const std::string& EU4Path, const Mods& mods)
+{
+	Log(LogLevel::Info) << "-> Loading Religions";
+	registerKeys();
+
+	for (const auto& filename: commonItems::GetAllFilesInFolder(EU4Path + "/common/religions/"))
+		parseFile(EU4Path + "/common/religions/" + filename);
+
+	for (const auto& modPath: mods | std::views::values)
+		for (const auto& filename: commonItems::GetAllFilesInFolder(modPath + "/common/religions/"))
+			parseFile(modPath + "/common/religions/" + filename);
+
+	clearRegisteredKeywords();
+	Log(LogLevel::Info) << "<> Loaded " << theReligions.size() << " religions.";
+}
+
+void EU4::ReligionLoader::loadReligions(std::istream& theStream)
+{
+	registerKeys();
+	parseStream(theStream);
+	clearRegisteredKeywords();
+}
+
+void EU4::ReligionLoader::registerKeys()
+{
+	registerRegex(commonItems::stringRegex, [this](const std::string& unused, std::istream& theStream) {
+		ReligionParser newGroup(theStream);
+		const auto fetchedReligions = newGroup.takeReligions();
+		theReligions.insert(fetchedReligions.begin(), fetchedReligions.end());
+	});
+	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
+}

--- a/EU4toV3/Source/EU4World/ReligionLoader/ReligionLoader.h
+++ b/EU4toV3/Source/EU4World/ReligionLoader/ReligionLoader.h
@@ -1,0 +1,26 @@
+#ifndef RELIGION_LOADER
+#define RELIGION_LOADER
+#include "Parser.h"
+#include <set>
+#include "Mods/ModLoader.h"
+
+namespace EU4
+{
+class ReligionLoader: commonItems::parser
+{
+  public:
+	ReligionLoader() = default;
+
+	void loadReligions(const std::string& EU4Path, const Mods& mods);
+	void loadReligions(std::istream& theStream);
+
+	[[nodiscard]] const auto& getAllReligions() const { return theReligions; }
+
+  private:
+	void registerKeys();
+
+	std::set<std::string> theReligions;
+};
+} // namespace EU4
+
+#endif // RELIGION_LOADER

--- a/EU4toV3/Source/EU4World/ReligionLoader/ReligionParser.cpp
+++ b/EU4toV3/Source/EU4World/ReligionLoader/ReligionParser.cpp
@@ -1,0 +1,29 @@
+#include "ReligionParser.h"
+#include "ParserHelpers.h"
+#include "CommonRegexes.h"
+
+EU4::ReligionParser::ReligionParser(std::istream& theStream)
+{
+	registerKeys();
+	parseStream(theStream);
+	clearRegisteredKeywords();
+}
+
+void EU4::ReligionParser::registerKeys()
+{
+	registerKeyword("defender_of_faith", commonItems::ignoreItem);
+	registerKeyword("can_form_personal_unions", commonItems::ignoreItem);
+	registerKeyword("center_of_religion", commonItems::ignoreItem);
+	registerKeyword("flags_with_emblem_percentage", commonItems::ignoreItem);
+	registerKeyword("flag_emblem_index_range", commonItems::ignoreItem);
+	registerKeyword("ai_will_propagate_through_trade", commonItems::ignoreItem);
+	registerKeyword("religious_schools", commonItems::ignoreItem);
+	registerKeyword("harmonized_modifier", commonItems::ignoreItem);
+	registerKeyword("crusade_name", commonItems::ignoreItem);
+
+	registerRegex(commonItems::stringRegex, [this](const std::string& religionName, std::istream& theStream) {
+		commonItems::ignoreItem(religionName, theStream);
+		religions.insert(religionName);
+	});
+	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
+}

--- a/EU4toV3/Source/EU4World/ReligionLoader/ReligionParser.h
+++ b/EU4toV3/Source/EU4World/ReligionLoader/ReligionParser.h
@@ -1,0 +1,21 @@
+#ifndef RELIGIONPARSER
+#define RELIGIONPARSER
+#include "Parser.h"
+#include <set>
+
+namespace EU4
+{
+class ReligionParser: commonItems::parser
+{
+  public:
+	ReligionParser(std::istream& theStream);
+	auto takeReligions() { return std::move(religions); }
+
+  private:
+	void registerKeys();
+
+	std::set<std::string> religions;
+};
+} // namespace EU4
+
+#endif // RELIGIONPARSER

--- a/EU4toV3/Source/EU4World/World.cpp
+++ b/EU4toV3/Source/EU4World/World.cpp
@@ -51,6 +51,8 @@ EU4::World::World(const Configuration& theConfiguration, const mappers::Converte
 	Log(LogLevel::Progress) << "15 %";
 
 	// With mods loaded we can init stuff that requires them.
+	religionLoader.loadReligions(EU4Path, mods);
+	cultureLoader.loadCultures(EU4Path, mods);
 	Log(LogLevel::Progress) << "16 %";
 
 	Log(LogLevel::Info) << "*** Building world ***";

--- a/EU4toV3/Source/EU4World/World.h
+++ b/EU4toV3/Source/EU4World/World.h
@@ -6,6 +6,8 @@
 #include "Parser.h"
 #include "ConverterVersion/ConverterVersion.h"
 #include "RegionManager/RegionManager.h"
+#include "ReligionLoader/ReligionLoader.h"
+#include "CultureLoader/CultureLoader.h"
 
 namespace EU4
 {
@@ -44,6 +46,8 @@ class World: commonItems::parser
 	int eu4Seed = 0;
 
 	RegionManager regionManager;
+	ReligionLoader religionLoader;
+	CultureLoader cultureLoader;
 };
 } // namespace EU4
 

--- a/EU4toV3Tests/EU4ToV3Tests.vcxproj
+++ b/EU4toV3Tests/EU4ToV3Tests.vcxproj
@@ -157,7 +157,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalIncludeDirectories>../commonItems;../googletest/googletest;../googletest/googletest/include;../googletest/googlemock;../googletest/googlemock/include;../EU4toV3/Source;../EU4toV3/Source/EU4World;../EU4toV3/Source/Mappers;../EU4toV3/Source/V3World</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../commonItems;../googletest/googletest;../googletest/googletest/include;../googletest/googlemock;../googletest/googlemock/include;../EU4toV3/Source;../EU4toV3/Source/EU4World;../EU4toV3/Source/Mappers;../EU4toV3/Source/V3World;../EU4toV3/Source/Configuration</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;_SILENCE_CXX20_U8PATH_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
@@ -181,23 +181,34 @@
     <ClCompile Include="..\commonItems\ParserHelpers.cpp" />
     <ClCompile Include="..\commonItems\StringUtils.cpp" />
     <ClCompile Include="..\commonItems\WinUtils.cpp" />
+    <ClCompile Include="..\EU4toV3\Source\Configuration\Configuration.cpp" />
+    <ClCompile Include="..\EU4toV3\Source\EU4World\CultureLoader\CultureGroupParser.cpp" />
+    <ClCompile Include="..\EU4toV3\Source\EU4World\CultureLoader\CultureLoader.cpp" />
+    <ClCompile Include="..\EU4toV3\Source\EU4World\CultureLoader\CultureParser.cpp" />
     <ClCompile Include="..\EU4toV3\Source\EU4World\Mods\ModNames.cpp" />
     <ClCompile Include="..\EU4toV3\Source\EU4World\Mods\ModParser.cpp" />
     <ClCompile Include="..\EU4toV3\Source\EU4World\RegionManager\Area.cpp" />
     <ClCompile Include="..\EU4toV3\Source\EU4World\RegionManager\Region.cpp" />
     <ClCompile Include="..\EU4toV3\Source\EU4World\RegionManager\RegionManager.cpp" />
     <ClCompile Include="..\EU4toV3\Source\EU4World\RegionManager\SuperRegion.cpp" />
+    <ClCompile Include="..\EU4toV3\Source\EU4World\ReligionLoader\ReligionLoader.cpp" />
+    <ClCompile Include="..\EU4toV3\Source\EU4World\ReligionLoader\ReligionParser.cpp" />
     <ClCompile Include="..\EU4toV3\Source\Mappers\ConverterVersion\ConverterVersion.cpp" />
     <ClCompile Include="..\EU4toV3\Source\V3World\Output\outConverterVersion.cpp" />
     <ClCompile Include="..\googletest\googlemock\src\gmock-all.cc" />
     <ClCompile Include="..\googletest\googletest\src\gtest-all.cc" />
     <ClCompile Include="..\googletest\googletest\src\gtest_main.cc" />
+    <ClCompile Include="EU4WorldTests\CultureLoaderTests\CultureLoaderTests.cpp" />
+    <ClCompile Include="EU4WorldTests\CultureLoaderTests\CultureGroupParserTests.cpp" />
+    <ClCompile Include="EU4WorldTests\CultureLoaderTests\CultureParserTests.cpp" />
     <ClCompile Include="EU4WorldTests\ModTests\ModNamesTests.cpp" />
     <ClCompile Include="EU4WorldTests\ModTests\ModParserTests.cpp" />
     <ClCompile Include="EU4WorldTests\RegionManagerTests\AreaTests.cpp" />
     <ClCompile Include="EU4WorldTests\RegionManagerTests\RegionManagerTests.cpp" />
     <ClCompile Include="EU4WorldTests\RegionManagerTests\RegionTests.cpp" />
     <ClCompile Include="EU4WorldTests\RegionManagerTests\SuperRegionTests.cpp" />
+    <ClCompile Include="EU4WorldTests\ReligionLoaderTests\ReligionParserTests.cpp" />
+    <ClCompile Include="EU4WorldTests\ReligionLoaderTests\ReligionLoaderTests.cpp" />
     <ClCompile Include="MapperTests\ConverterVersion\ConverterVersionTests.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/EU4toV3Tests/EU4ToV3Tests.vcxproj.filters
+++ b/EU4toV3Tests/EU4ToV3Tests.vcxproj.filters
@@ -85,6 +85,39 @@
     <ClCompile Include="EU4WorldTests\RegionManagerTests\SuperRegionTests.cpp">
       <Filter>EU4WorldTests\RegionManagerTests</Filter>
     </ClCompile>
+    <ClCompile Include="EU4WorldTests\ReligionLoaderTests\ReligionParserTests.cpp">
+      <Filter>EU4WorldTests\ReligionLoaderTests</Filter>
+    </ClCompile>
+    <ClCompile Include="EU4WorldTests\ReligionLoaderTests\ReligionLoaderTests.cpp">
+      <Filter>EU4WorldTests\ReligionLoaderTests</Filter>
+    </ClCompile>
+    <ClCompile Include="EU4WorldTests\CultureLoaderTests\CultureLoaderTests.cpp">
+      <Filter>EU4WorldTests\CultureLoaderTests</Filter>
+    </ClCompile>
+    <ClCompile Include="EU4WorldTests\CultureLoaderTests\CultureGroupParserTests.cpp">
+      <Filter>EU4WorldTests\CultureLoaderTests</Filter>
+    </ClCompile>
+    <ClCompile Include="EU4WorldTests\CultureLoaderTests\CultureParserTests.cpp">
+      <Filter>EU4WorldTests\CultureLoaderTests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\EU4toV3\Source\EU4World\CultureLoader\CultureGroupParser.cpp">
+      <Filter>ConverterFiles\EU4World\CultureLoader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\EU4toV3\Source\EU4World\CultureLoader\CultureLoader.cpp">
+      <Filter>ConverterFiles\EU4World\CultureLoader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\EU4toV3\Source\EU4World\CultureLoader\CultureParser.cpp">
+      <Filter>ConverterFiles\EU4World\CultureLoader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\EU4toV3\Source\EU4World\ReligionLoader\ReligionLoader.cpp">
+      <Filter>ConverterFiles\EU4World\ReligionLoader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\EU4toV3\Source\EU4World\ReligionLoader\ReligionParser.cpp">
+      <Filter>ConverterFiles\EU4World\ReligionLoader</Filter>
+    </ClCompile>
+    <ClCompile Include="..\EU4toV3\Source\Configuration\Configuration.cpp">
+      <Filter>ConverterFiles\Configuration</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="EU4WorldTests">
@@ -134,6 +167,21 @@
     </Filter>
     <Filter Include="EU4WorldTests\RegionManagerTests">
       <UniqueIdentifier>{b4ef8576-4f81-4ffc-a2b5-2afaea3e0d98}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ConverterFiles\EU4World\ReligionLoader">
+      <UniqueIdentifier>{c9b91cb8-8474-470a-8894-f1876573e2cf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ConverterFiles\EU4World\CultureLoader">
+      <UniqueIdentifier>{0713b92a-1a02-4277-8f7b-00b24761585b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="EU4WorldTests\ReligionLoaderTests">
+      <UniqueIdentifier>{18a88e07-3562-4c4c-a69c-12e8b53fc61b}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="EU4WorldTests\CultureLoaderTests">
+      <UniqueIdentifier>{6a7bd286-d8e7-4d71-a1d5-eb0da012af1a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="ConverterFiles\Configuration">
+      <UniqueIdentifier>{b5006ca4-78ca-4792-b44e-f2bae1ad4297}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>

--- a/EU4toV3Tests/EU4WorldTests/CultureLoaderTests/CultureGroupParserTests.cpp
+++ b/EU4toV3Tests/EU4WorldTests/CultureLoaderTests/CultureGroupParserTests.cpp
@@ -1,0 +1,78 @@
+#include "CultureLoader/CultureGroupParser.h"
+#include "CultureLoader/CultureParser.h"
+#include "gtest/gtest.h"
+
+TEST(EU4World_CultureGroupParserTests, nameCanBeSet)
+{
+	std::stringstream input;
+	const EU4::CultureGroupParser group("name", input);
+
+	EXPECT_EQ("name", group.getName());
+}
+
+TEST(EU4World_CultureGroupParserTests, culturesCanBeLoaded)
+{
+	std::stringstream input;
+	input << "someculture = {}\n";
+	input << "otherculture = {}\n";
+	const EU4::CultureGroupParser group("name", input);
+
+	EXPECT_EQ(2, group.getCultures().size());
+	EXPECT_TRUE(group.getCultures().contains("someculture"));
+	EXPECT_TRUE(group.getCultures().contains("otherculture"));
+}
+
+TEST(MEU4World_CultureGroupParserTests, culturesCanBeMerged)
+{
+	std::stringstream input;
+	input << "someculture = {\n";
+	input << "\tmale_names = { bob }\n";
+	input << "\tfemale_names = { boba }\n";
+	input << "\tdynasty_names = { bobby }\n";
+	input << "}\n";
+	EU4::CultureGroupParser group("name", input);
+
+	std::stringstream input2;
+	input2 << "male_names = { jon }\n";
+	input2 << "female_names = { jona }\n";
+	input2 << "dynasty_names = { jonny }\n";
+	const auto sameCulture = EU4::CultureParser(input2);
+
+	group.mergeCulture("someculture", sameCulture);
+
+	const auto someCulture = group.getCultures().at("someculture");
+
+	EXPECT_EQ(2, someCulture.getMaleNames().size());
+	EXPECT_EQ("bob", someCulture.getMaleNames()[0]);
+	EXPECT_EQ("jon", someCulture.getMaleNames()[1]);
+	EXPECT_EQ(2, someCulture.getFemaleNames().size());
+	EXPECT_EQ("boba", someCulture.getFemaleNames()[0]);
+	EXPECT_EQ("jona", someCulture.getFemaleNames()[1]);
+	EXPECT_EQ(2, someCulture.getDynastyNames().size());
+	EXPECT_EQ("bobby", someCulture.getDynastyNames()[0]);
+	EXPECT_EQ("jonny", someCulture.getDynastyNames()[1]);
+}
+
+TEST(EU4World_CultureGroupParserTests, unmergeableCulturesAreAddedToGroup)
+{
+	std::stringstream input;
+	input << "someculture = {\n";
+	input << "\tmale_names = { bob }\n";
+	input << "\tfemale_names = { boba }\n";
+	input << "\tdynasty_names = { bobby }\n";
+	input << "}\n";
+	EU4::CultureGroupParser group("name", input);
+
+	std::stringstream input2;
+	input2 << "male_names = { jon }\n";
+	input2 << "female_names = { jona }\n";
+	input2 << "dynasty_names = { jonny }\n";
+	const auto otherCulture = EU4::CultureParser(input2);
+
+	group.mergeCulture("otherculture", otherCulture);
+
+	EXPECT_EQ(2, group.getCultures().size());
+	EXPECT_TRUE(group.getCultures().contains("someculture"));
+	EXPECT_TRUE(group.getCultures().contains("otherculture"));
+}
+

--- a/EU4toV3Tests/EU4WorldTests/CultureLoaderTests/CultureGroupParserTests.cpp
+++ b/EU4toV3Tests/EU4WorldTests/CultureLoaderTests/CultureGroupParserTests.cpp
@@ -1,6 +1,8 @@
 #include "CultureLoader/CultureGroupParser.h"
 #include "CultureLoader/CultureParser.h"
 #include "gtest/gtest.h"
+#include <gmock/gmock-matchers.h>
+using testing::ElementsAre;
 
 TEST(EU4World_CultureGroupParserTests, nameCanBeSet)
 {
@@ -22,7 +24,7 @@ TEST(EU4World_CultureGroupParserTests, culturesCanBeLoaded)
 	EXPECT_TRUE(group.getCultures().contains("otherculture"));
 }
 
-TEST(MEU4World_CultureGroupParserTests, culturesCanBeMerged)
+TEST(EU4World_CultureGroupParserTests, culturesCanBeMerged)
 {
 	std::stringstream input;
 	input << "someculture = {\n";
@@ -40,17 +42,11 @@ TEST(MEU4World_CultureGroupParserTests, culturesCanBeMerged)
 
 	group.mergeCulture("someculture", sameCulture);
 
-	const auto someCulture = group.getCultures().at("someculture");
+	const auto& someCulture = group.getCultures().at("someculture");
 
-	EXPECT_EQ(2, someCulture.getMaleNames().size());
-	EXPECT_EQ("bob", someCulture.getMaleNames()[0]);
-	EXPECT_EQ("jon", someCulture.getMaleNames()[1]);
-	EXPECT_EQ(2, someCulture.getFemaleNames().size());
-	EXPECT_EQ("boba", someCulture.getFemaleNames()[0]);
-	EXPECT_EQ("jona", someCulture.getFemaleNames()[1]);
-	EXPECT_EQ(2, someCulture.getDynastyNames().size());
-	EXPECT_EQ("bobby", someCulture.getDynastyNames()[0]);
-	EXPECT_EQ("jonny", someCulture.getDynastyNames()[1]);
+	EXPECT_THAT(someCulture.getMaleNames(), ElementsAre("bob", "jon"));
+	EXPECT_THAT(someCulture.getFemaleNames(), ElementsAre("boba", "jona"));
+	EXPECT_THAT(someCulture.getDynastyNames(), ElementsAre("bobby", "jonny"));
 }
 
 TEST(EU4World_CultureGroupParserTests, unmergeableCulturesAreAddedToGroup)
@@ -75,4 +71,3 @@ TEST(EU4World_CultureGroupParserTests, unmergeableCulturesAreAddedToGroup)
 	EXPECT_TRUE(group.getCultures().contains("someculture"));
 	EXPECT_TRUE(group.getCultures().contains("otherculture"));
 }
-

--- a/EU4toV3Tests/EU4WorldTests/CultureLoaderTests/CultureLoaderTests.cpp
+++ b/EU4toV3Tests/EU4WorldTests/CultureLoaderTests/CultureLoaderTests.cpp
@@ -1,0 +1,45 @@
+#include "CultureLoader/CultureParser.h"
+#include "CultureLoader/CultureGroupParser.h"
+#include "CultureLoader/CultureLoader.h"
+#include "gtest/gtest.h"
+
+TEST(EU4World_CultureLoaderTests, cultureGroupsCanBeLoaded)
+{
+	std::stringstream input;
+	input << "groupA = { cultureA = {} }\n";
+	input << "groupB = { cultureB = {} }\n";
+	EU4::CultureLoader groups;
+	groups.loadCultures(input);
+
+	EXPECT_EQ(2, groups.getCultureGroupsMap().size());
+	EXPECT_TRUE(groups.getCultureGroupsMap().contains("groupA"));
+	EXPECT_TRUE(groups.getCultureGroupsMap().contains("groupB"));
+}
+
+TEST(EU4World_CultureLoaderTests, mergableCultureGroupsCanBeMerged)
+{
+	std::stringstream input;
+	input << "groupA = { cultureA = {} }\n";
+	input << "groupB = { cultureB = {} }\n";
+	EU4::CultureLoader groups;
+	groups.loadCultures(input);
+
+	std::stringstream input2;
+	input2 << "groupA = { cultureC = {} }\n";
+	input2 << "groupB = { cultureD = {} }\n";
+	groups.loadCultures(input2);
+
+	EXPECT_EQ(2, groups.getCultureGroupsMap().size());
+	EXPECT_TRUE(groups.getCultureGroupsMap().contains("groupA"));
+	EXPECT_TRUE(groups.getCultureGroupsMap().contains("groupB"));
+
+	const auto& cultureGroupA = groups.getCultureGroupsMap().at("groupA");
+	EXPECT_EQ(2, cultureGroupA.getCultures().size());
+	EXPECT_TRUE(cultureGroupA.getCultures().contains("cultureA"));
+	EXPECT_TRUE(cultureGroupA.getCultures().contains("cultureC"));
+
+	const auto& cultureGroupB = groups.getCultureGroupsMap().at("groupB");
+	EXPECT_EQ(2, cultureGroupB.getCultures().size());
+	EXPECT_TRUE(cultureGroupB.getCultures().contains("cultureB"));
+	EXPECT_TRUE(cultureGroupB.getCultures().contains("cultureD"));
+}

--- a/EU4toV3Tests/EU4WorldTests/CultureLoaderTests/CultureParserTests.cpp
+++ b/EU4toV3Tests/EU4WorldTests/CultureLoaderTests/CultureParserTests.cpp
@@ -1,5 +1,7 @@
 #include "CultureLoader/CultureParser.h"
 #include "gtest/gtest.h"
+#include <gmock/gmock-matchers.h>
+using testing::ElementsAre;
 
 TEST(EU4World_CultureParserTests, primitivesDefaultToDefaults)
 {
@@ -18,17 +20,13 @@ TEST(EU4World_CultureParserTests, maleNamesCanBeRetrievedAndAdded)
 	input << "male_names = { Bob Jon }";
 	EU4::CultureParser culture(input);
 
-	EXPECT_EQ(2, culture.getMaleNames().size());
-	EXPECT_EQ("Bob", culture.getMaleNames()[0]);
-	EXPECT_EQ("Jon", culture.getMaleNames()[1]);
+	EXPECT_THAT(culture.getMaleNames(), ElementsAre("Bob", "Jon"));
 
 	const std::vector<std::string> moreNames = {"Dod", "Kro"};
 
 	culture.addMaleNames(moreNames);
 
-	EXPECT_EQ(4, culture.getMaleNames().size());
-	EXPECT_EQ("Dod", culture.getMaleNames()[2]);
-	EXPECT_EQ("Kro", culture.getMaleNames()[3]);
+	EXPECT_THAT(culture.getMaleNames(), ElementsAre("Bob", "Jon", "Dod", "Kro"));
 }
 
 TEST(EU4World_CultureParserTests, femaleNamesCanBeRetrievedAndAdded)
@@ -37,17 +35,13 @@ TEST(EU4World_CultureParserTests, femaleNamesCanBeRetrievedAndAdded)
 	input << "female_names = { Bob Jon }";
 	EU4::CultureParser culture(input);
 
-	EXPECT_EQ(2, culture.getFemaleNames().size());
-	EXPECT_EQ("Bob", culture.getFemaleNames()[0]);
-	EXPECT_EQ("Jon", culture.getFemaleNames()[1]);
+	EXPECT_THAT(culture.getFemaleNames(), ElementsAre("Bob", "Jon"));
 
 	const std::vector<std::string> moreNames = {"Dod", "Kro"};
 
 	culture.addFemaleNames(moreNames);
 
-	EXPECT_EQ(4, culture.getFemaleNames().size());
-	EXPECT_EQ("Dod", culture.getFemaleNames()[2]);
-	EXPECT_EQ("Kro", culture.getFemaleNames()[3]);
+	EXPECT_THAT(culture.getFemaleNames(), ElementsAre("Bob", "Jon", "Dod", "Kro"));
 }
 
 TEST(EU4World_CultureParserTests, dynastyNamesCanBeRetrievedAndAdded)
@@ -56,17 +50,13 @@ TEST(EU4World_CultureParserTests, dynastyNamesCanBeRetrievedAndAdded)
 	input << "dynasty_names = { Bob Jon }";
 	EU4::CultureParser culture(input);
 
-	EXPECT_EQ(2, culture.getDynastyNames().size());
-	EXPECT_EQ("Bob", culture.getDynastyNames()[0]);
-	EXPECT_EQ("Jon", culture.getDynastyNames()[1]);
+	EXPECT_THAT(culture.getDynastyNames(), ElementsAre("Bob", "Jon"));
 
 	const std::vector<std::string> moreNames = {"Dod", "Kro"};
 
 	culture.addDynastyNames(moreNames);
 
-	EXPECT_EQ(4, culture.getDynastyNames().size());
-	EXPECT_EQ("Dod", culture.getDynastyNames()[2]);
-	EXPECT_EQ("Kro", culture.getDynastyNames()[3]);
+	EXPECT_THAT(culture.getDynastyNames(), ElementsAre("Bob", "Jon", "Dod", "Kro"));
 }
 
 TEST(Mappers_CultureTests, primaryTagCanBeLoadedAndAdded)
@@ -80,4 +70,3 @@ TEST(Mappers_CultureTests, primaryTagCanBeLoadedAndAdded)
 	culture.setPrimaryTag("GAT");
 	EXPECT_EQ("GAT", culture.getPrimaryTag());
 }
-

--- a/EU4toV3Tests/EU4WorldTests/CultureLoaderTests/CultureParserTests.cpp
+++ b/EU4toV3Tests/EU4WorldTests/CultureLoaderTests/CultureParserTests.cpp
@@ -1,0 +1,83 @@
+#include "CultureLoader/CultureParser.h"
+#include "gtest/gtest.h"
+
+TEST(EU4World_CultureParserTests, primitivesDefaultToDefaults)
+{
+	std::stringstream input;
+	const EU4::CultureParser culture(input);
+
+	EXPECT_TRUE(culture.getMaleNames().empty());
+	EXPECT_TRUE(culture.getFemaleNames().empty());
+	EXPECT_TRUE(culture.getDynastyNames().empty());
+	EXPECT_TRUE(culture.getPrimaryTag().empty());
+}
+
+TEST(EU4World_CultureParserTests, maleNamesCanBeRetrievedAndAdded)
+{
+	std::stringstream input;
+	input << "male_names = { Bob Jon }";
+	EU4::CultureParser culture(input);
+
+	EXPECT_EQ(2, culture.getMaleNames().size());
+	EXPECT_EQ("Bob", culture.getMaleNames()[0]);
+	EXPECT_EQ("Jon", culture.getMaleNames()[1]);
+
+	const std::vector<std::string> moreNames = {"Dod", "Kro"};
+
+	culture.addMaleNames(moreNames);
+
+	EXPECT_EQ(4, culture.getMaleNames().size());
+	EXPECT_EQ("Dod", culture.getMaleNames()[2]);
+	EXPECT_EQ("Kro", culture.getMaleNames()[3]);
+}
+
+TEST(EU4World_CultureParserTests, femaleNamesCanBeRetrievedAndAdded)
+{
+	std::stringstream input;
+	input << "female_names = { Bob Jon }";
+	EU4::CultureParser culture(input);
+
+	EXPECT_EQ(2, culture.getFemaleNames().size());
+	EXPECT_EQ("Bob", culture.getFemaleNames()[0]);
+	EXPECT_EQ("Jon", culture.getFemaleNames()[1]);
+
+	const std::vector<std::string> moreNames = {"Dod", "Kro"};
+
+	culture.addFemaleNames(moreNames);
+
+	EXPECT_EQ(4, culture.getFemaleNames().size());
+	EXPECT_EQ("Dod", culture.getFemaleNames()[2]);
+	EXPECT_EQ("Kro", culture.getFemaleNames()[3]);
+}
+
+TEST(EU4World_CultureParserTests, dynastyNamesCanBeRetrievedAndAdded)
+{
+	std::stringstream input;
+	input << "dynasty_names = { Bob Jon }";
+	EU4::CultureParser culture(input);
+
+	EXPECT_EQ(2, culture.getDynastyNames().size());
+	EXPECT_EQ("Bob", culture.getDynastyNames()[0]);
+	EXPECT_EQ("Jon", culture.getDynastyNames()[1]);
+
+	const std::vector<std::string> moreNames = {"Dod", "Kro"};
+
+	culture.addDynastyNames(moreNames);
+
+	EXPECT_EQ(4, culture.getDynastyNames().size());
+	EXPECT_EQ("Dod", culture.getDynastyNames()[2]);
+	EXPECT_EQ("Kro", culture.getDynastyNames()[3]);
+}
+
+TEST(Mappers_CultureTests, primaryTagCanBeLoadedAndAdded)
+{
+	std::stringstream input;
+	input << "primary = TAG";
+	EU4::CultureParser culture(input);
+
+	EXPECT_EQ("TAG", culture.getPrimaryTag());
+
+	culture.setPrimaryTag("GAT");
+	EXPECT_EQ("GAT", culture.getPrimaryTag());
+}
+

--- a/EU4toV3Tests/EU4WorldTests/ReligionLoaderTests/ReligionLoaderTests.cpp
+++ b/EU4toV3Tests/EU4WorldTests/ReligionLoaderTests/ReligionLoaderTests.cpp
@@ -1,0 +1,58 @@
+#include "ReligionLoader/ReligionLoader.h"
+#include "ReligionLoader/ReligionParser.h"
+#include "gtest/gtest.h"
+/*
+TEST(EU4World_ReligionLoaderTests, religionsDefaultToEmpty)
+{
+	std::stringstream input;
+	EU4::ReligionLoader theReligions;
+	theReligions.loadReligions(input);
+
+	EXPECT_TRUE(theReligions.getAllReligions().empty());
+}
+
+TEST(EU4World_ReligionLoaderTests, religionCanBeImported)
+{
+	std::stringstream input;
+	input << "religion_group = {\n";
+	input << "\treligion = {}\n";
+	input << "}";
+	EU4::ReligionLoader theReligions;
+	theReligions.loadReligions(input);
+
+	EXPECT_EQ(1, theReligions.getAllReligions().size());
+	EXPECT_TRUE(theReligions.getAllReligions().contains("religion"));
+}
+
+TEST(EU4World_ReligionLoaderTests, multipleReligionCanBeImported)
+{
+	std::stringstream input;
+	input << "religion_group = {\n";
+	input << "\treligion = {}\n";
+	input << "\tanother_religion = {}\n";
+	input << "}";
+	EU4::ReligionLoader theReligions;
+	theReligions.loadReligions(input);
+
+	EXPECT_EQ(theReligions.getAllReligions().size(), 2);
+	EXPECT_TRUE(theReligions.getAllReligions().contains("religion"));
+	EXPECT_TRUE(theReligions.getAllReligions().contains("another_religion"));
+}
+
+TEST(EU4World_ReligionLoaderTests, multipleReligionGroupsCanBeImported)
+{
+	std::stringstream input;
+	input << "religion_group = {\n";
+	input << "\treligion = {}\n";
+	input << "}\n";
+	input << "another_religion_group = {\n";
+	input << "\tanother_religion = {}\n";
+	input << "}";
+	EU4::ReligionLoader theReligions;
+	theReligions.loadReligions(input);
+
+	EXPECT_EQ(theReligions.getAllReligions().size(), 2);
+	EXPECT_TRUE(theReligions.getAllReligions().contains("religion"));
+	EXPECT_TRUE(theReligions.getAllReligions().contains("another_religion"));
+}
+*/

--- a/EU4toV3Tests/EU4WorldTests/ReligionLoaderTests/ReligionLoaderTests.cpp
+++ b/EU4toV3Tests/EU4WorldTests/ReligionLoaderTests/ReligionLoaderTests.cpp
@@ -1,7 +1,7 @@
 #include "ReligionLoader/ReligionLoader.h"
 #include "ReligionLoader/ReligionParser.h"
 #include "gtest/gtest.h"
-/*
+
 TEST(EU4World_ReligionLoaderTests, religionsDefaultToEmpty)
 {
 	std::stringstream input;
@@ -55,4 +55,3 @@ TEST(EU4World_ReligionLoaderTests, multipleReligionGroupsCanBeImported)
 	EXPECT_TRUE(theReligions.getAllReligions().contains("religion"));
 	EXPECT_TRUE(theReligions.getAllReligions().contains("another_religion"));
 }
-*/

--- a/EU4toV3Tests/EU4WorldTests/ReligionLoaderTests/ReligionLoaderTests.cpp
+++ b/EU4toV3Tests/EU4WorldTests/ReligionLoaderTests/ReligionLoaderTests.cpp
@@ -1,6 +1,8 @@
 #include "ReligionLoader/ReligionLoader.h"
 #include "ReligionLoader/ReligionParser.h"
 #include "gtest/gtest.h"
+#include <gmock/gmock-matchers.h>
+using testing::UnorderedElementsAre;
 
 TEST(EU4World_ReligionLoaderTests, religionsDefaultToEmpty)
 {
@@ -20,11 +22,10 @@ TEST(EU4World_ReligionLoaderTests, religionCanBeImported)
 	EU4::ReligionLoader theReligions;
 	theReligions.loadReligions(input);
 
-	EXPECT_EQ(1, theReligions.getAllReligions().size());
-	EXPECT_TRUE(theReligions.getAllReligions().contains("religion"));
+	EXPECT_THAT(theReligions.getAllReligions(), UnorderedElementsAre("religion"));
 }
 
-TEST(EU4World_ReligionLoaderTests, multipleReligionCanBeImported)
+TEST(EU4World_ReligionLoaderTests, multipleReligionsCanBeImported)
 {
 	std::stringstream input;
 	input << "religion_group = {\n";
@@ -34,9 +35,7 @@ TEST(EU4World_ReligionLoaderTests, multipleReligionCanBeImported)
 	EU4::ReligionLoader theReligions;
 	theReligions.loadReligions(input);
 
-	EXPECT_EQ(theReligions.getAllReligions().size(), 2);
-	EXPECT_TRUE(theReligions.getAllReligions().contains("religion"));
-	EXPECT_TRUE(theReligions.getAllReligions().contains("another_religion"));
+	EXPECT_THAT(theReligions.getAllReligions(), UnorderedElementsAre("religion", "another_religion"));
 }
 
 TEST(EU4World_ReligionLoaderTests, multipleReligionGroupsCanBeImported)
@@ -51,7 +50,5 @@ TEST(EU4World_ReligionLoaderTests, multipleReligionGroupsCanBeImported)
 	EU4::ReligionLoader theReligions;
 	theReligions.loadReligions(input);
 
-	EXPECT_EQ(theReligions.getAllReligions().size(), 2);
-	EXPECT_TRUE(theReligions.getAllReligions().contains("religion"));
-	EXPECT_TRUE(theReligions.getAllReligions().contains("another_religion"));
+	EXPECT_THAT(theReligions.getAllReligions(), UnorderedElementsAre("religion", "another_religion"));
 }

--- a/EU4toV3Tests/EU4WorldTests/ReligionLoaderTests/ReligionParserTests.cpp
+++ b/EU4toV3Tests/EU4WorldTests/ReligionLoaderTests/ReligionParserTests.cpp
@@ -1,5 +1,7 @@
 #include "ReligionLoader/ReligionParser.h"
 #include "gtest/gtest.h"
+#include <gmock/gmock-matchers.h>
+using testing::UnorderedElementsAre;
 
 TEST(EU4World_ReligionParserTests, religionsDefaultToEmpty)
 {
@@ -30,5 +32,5 @@ TEST(EU4World_ReligionParserTests, religionsCanBeImported)
 	EU4::ReligionParser religionGroup(input);
 	const auto theReligions = religionGroup.takeReligions();
 
-	EXPECT_TRUE(theReligions.contains("zoroastrian"));
+	EXPECT_THAT(theReligions, UnorderedElementsAre("zoroastrian"));
 }

--- a/EU4toV3Tests/EU4WorldTests/ReligionLoaderTests/ReligionParserTests.cpp
+++ b/EU4toV3Tests/EU4WorldTests/ReligionLoaderTests/ReligionParserTests.cpp
@@ -1,0 +1,35 @@
+#include "ReligionLoader/ReligionParser.h"
+#include "gtest/gtest.h"
+/*
+TEST(EU4World_ReligionParserTests, religionsDefaultToEmpty)
+{
+	std::stringstream input;
+	EU4::ReligionParser religionGroup(input);
+	const auto theReligions = religionGroup.takeReligions();
+
+	EXPECT_TRUE(theReligions.empty());
+}
+
+TEST(EU4World_ReligionParserTests, religionsCanBeImported)
+{
+	std::stringstream input;
+	// These keys is not relevant but all unnecessary named keys must be specifically ignored.
+	input << "defender_of_faith = yes\n";
+	input << "can_form_personal_unions = yes\n";
+	input << "center_of_religion = 385 # Mecca\n";
+	input << "flags_with_emblem_percentage = 33\n";
+	input << "flag_emblem_index_range = { 110 110 }\n";
+	input << "ai_will_propagate_through_trade = yes\n";
+	input << "religious_schools = { big block of bull }\n";
+	input << "zoroastrian = {\n"; // Name is relevant, content is not.
+	input << "\tabsolutely irrelevant\n";
+	input << "}\n";
+	input << "harmonized_modifier = harmonized_zoroastrian_group\n"; // also not relevant.
+	input << "crusade_name = HOLY_WAR\n";
+
+	EU4::ReligionParser religionGroup(input);
+	const auto theReligions = religionGroup.takeReligions();
+
+	EXPECT_TRUE(theReligions.contains("zoroastrian"));
+}
+*/

--- a/EU4toV3Tests/EU4WorldTests/ReligionLoaderTests/ReligionParserTests.cpp
+++ b/EU4toV3Tests/EU4WorldTests/ReligionLoaderTests/ReligionParserTests.cpp
@@ -1,6 +1,6 @@
 #include "ReligionLoader/ReligionParser.h"
 #include "gtest/gtest.h"
-/*
+
 TEST(EU4World_ReligionParserTests, religionsDefaultToEmpty)
 {
 	std::stringstream input;
@@ -32,4 +32,3 @@ TEST(EU4World_ReligionParserTests, religionsCanBeImported)
 
 	EXPECT_TRUE(theReligions.contains("zoroastrian"));
 }
-*/


### PR DESCRIPTION
These are straight loaders for eu4 culture and religion, no processing.
They are stripped versions of old ones, without pointers, neocultures and all that jazz.
Intended use is to just feed some processor down the road.