### PR TITLE
Altered Aachen Legacy Flags

### DIFF
--- a/EU4toV3/Data_Files/blankMod/output/common/coat_of_arms/coat_of_arms/99_legacy.txt
+++ b/EU4toV3/Data_Files/blankMod/output/common/coat_of_arms/coat_of_arms/99_legacy.txt
@@ -29,10 +29,12 @@ legacy_AAC = {
 	color1 = "yellow"
 
 	colored_emblem = {
-		texture = "ce_eagle.dds"
+		texture = "ce_aacheneagle.dds"
+		instance = { scale = { 0.5 0.8 } position = { 0.5 0.5 } } 
 		color1 = "black"
 		color2 = "red"
-	}
+		color3 = "white"
+	}	
 }
 legacy_AAC_communist = {
 	pattern = "pattern_solid.tga"
@@ -55,9 +57,11 @@ legacy_AAC_fascist = {
 	color2 = "yellow"
 
 	colored_emblem = {
-		texture = "ce_eagle.dds"
+		texture = "ce_aacheneagle.dds"
+		instance = { scale = { 0.5 0.8 } position = { 0.5 0.5 } } 
 		color1 = "black"
 		color2 = "red"
+		color3 = "white"
 	}
 }
 legacy_AAC_monarchy = {
@@ -65,9 +69,11 @@ legacy_AAC_monarchy = {
 	color1 = "yellow"
 
 	colored_emblem = {
-		texture = "ce_eagle.dds"
+		texture = "ce_aacheneagle.dds"
+		instance = { scale = { 0.5 0.8 } position = { 0.5 0.5 } } 
 		color1 = "black"
 		color2 = "red"
+		color3 = "white"
 	}
 }
 legacy_AAC_republic = {


### PR DESCRIPTION
Altered Aachen legacy flags default, monarchy, and fascist to use a new coloured emblem of a heraldic eagle abaisse, as in the Aachen coat of arms.

(This is the github account of Dapper Gamelord on the Paradox Game Converter Development discord. I've never collaborated in a git repo using github like this before so let me know if I've made any etiquette blunders or anything like that.)