### PR TITLE
Substate creation

### DIFF
--- a/EU4toV3/Source/V3World/ClayManager/ClayManager.cpp
+++ b/EU4toV3/Source/V3World/ClayManager/ClayManager.cpp
@@ -215,7 +215,7 @@ void V3::ClayManager::distributeChunksAcrossSubStates()
 	// Now build substates. Substates are divorced from chunks and no sensible direct link to original eu4 provinces can remain.
 	// That's why every province knows what chunk it belonged to and can work back from there.
 
-	buildSubStates(tagStateProvinces, sourceOwners);
+	substates = buildSubStates(tagStateProvinces, sourceOwners);
 
 	Log(LogLevel::Info) << "<> Substates organized, " << substates.size() << " produced.";
 }
@@ -253,8 +253,11 @@ std::pair<V3::ClayManager::EU4TagToStateToProvinceMap, V3::ClayManager::SourceOw
 	return {tagStateProvinces, sourceOwners};
 }
 
-void V3::ClayManager::buildSubStates(const EU4TagToStateToProvinceMap& tagStateProvinces, const SourceOwners& sourceOwners)
+std::vector<std::shared_ptr<V3::SubState>> V3::ClayManager::buildSubStates(const EU4TagToStateToProvinceMap& tagStateProvinces,
+	 const SourceOwners& sourceOwners) const
 {
+	std::vector<std::shared_ptr<SubState>> subStates;
+
 	for (const auto& [eu4tag, stateMap]: tagStateProvinces)
 		for (const auto& [stateName, provinces]: stateMap)
 		{
@@ -275,6 +278,8 @@ void V3::ClayManager::buildSubStates(const EU4TagToStateToProvinceMap& tagStateP
 			subState->state = states.at(stateName);
 
 			// Should be ok now.
-			substates.push_back(subState);
+			subStates.push_back(subState);
 		}
+
+	return subStates;
 }

--- a/EU4toV3/Source/V3World/ClayManager/ClayManager.h
+++ b/EU4toV3/Source/V3World/ClayManager/ClayManager.h
@@ -27,7 +27,7 @@ class ClayManager
 	[[nodiscard]] const auto& getStates() const { return states; }
 	[[nodiscard]] const auto& getSuperRegions() const { return superRegions; }
 	[[nodiscard]] const auto& getChunks() const { return chunks; }
-	[[nodiscard]] const auto& getSubstates() const { return substates; }
+	[[nodiscard]] const auto& getSubStates() const { return substates; }
 
   private:
 	using ProvinceMap = std::map<std::string, std::shared_ptr<Province>>;			// v3 province name->v3 province
@@ -37,7 +37,8 @@ class ClayManager
 
 	static [[nodiscard]] std::map<std::string, double> calcChunkOwnerWeights(const std::shared_ptr<Chunk>& chunk);
 	[[nodiscard]] std::pair<EU4TagToStateToProvinceMap, SourceOwners> sortChunkProvincesIntoTagStates() const;
-	void buildSubStates(const EU4TagToStateToProvinceMap& tagStateProvinces, const SourceOwners& sourceOwners);
+	[[nodiscard]] std::vector<std::shared_ptr<SubState>> buildSubStates(const EU4TagToStateToProvinceMap& tagStateProvinces,
+		 const SourceOwners& sourceOwners) const;
 
 	std::map<std::string, std::shared_ptr<State>> states;					// geographical entities
 	std::map<std::string, std::shared_ptr<SuperRegion>> superRegions; // geographical entities

--- a/EU4toV3/Source/V3World/ClayManager/ClayManager.h
+++ b/EU4toV3/Source/V3World/ClayManager/ClayManager.h
@@ -30,6 +30,15 @@ class ClayManager
 	[[nodiscard]] const auto& getSubstates() const { return substates; }
 
   private:
+	using ProvinceMap = std::map<std::string, std::shared_ptr<Province>>;			// v3 province name->v3 province
+	using StateToProvinceMap = std::map<std::string, ProvinceMap>;						// state name -> v3 provinces
+	using EU4TagToStateToProvinceMap = std::map<std::string, StateToProvinceMap>; // eu4 tag -> states and their provinces.
+	using SourceOwners = std::map<std::string, std::shared_ptr<EU4::Country>>;		// eu4tag, eu4country
+
+	static [[nodiscard]] std::map<std::string, double> calcChunkOwnerWeights(const std::shared_ptr<Chunk>& chunk);
+	[[nodiscard]] std::pair<EU4TagToStateToProvinceMap, SourceOwners> sortChunkProvincesIntoTagStates() const;
+	void buildSubStates(const EU4TagToStateToProvinceMap& tagStateProvinces, const SourceOwners& sourceOwners);
+
 	std::map<std::string, std::shared_ptr<State>> states;					// geographical entities
 	std::map<std::string, std::shared_ptr<SuperRegion>> superRegions; // geographical entities
 	std::map<std::string, std::shared_ptr<State>> provincesToStates;	// handy map for quickly referencing states;

--- a/EU4toV3/Source/V3World/ClayManager/ClayManager.h
+++ b/EU4toV3/Source/V3World/ClayManager/ClayManager.h
@@ -21,10 +21,13 @@ class ClayManager
 	void initializeSuperRegions(const std::string& v3Path);
 	void loadStatesIntoSuperRegions();
 	void generateChunks(const mappers::ProvinceMapper& provinceMapper, const EU4::ProvinceManager& provinceManager);
+	void unDisputeChunkOwnership(const std::map<std::string, std::shared_ptr<EU4::Country>>& sourceCountries);
+	void distributeChunksAcrossSubStates();
 
 	[[nodiscard]] const auto& getStates() const { return states; }
 	[[nodiscard]] const auto& getSuperRegions() const { return superRegions; }
 	[[nodiscard]] const auto& getChunks() const { return chunks; }
+	[[nodiscard]] const auto& getSubstates() const { return substates; }
 
   private:
 	std::map<std::string, std::shared_ptr<State>> states;					// geographical entities

--- a/EU4toV3/Source/V3World/ClayManager/StateLoader/Province.h
+++ b/EU4toV3/Source/V3World/ClayManager/StateLoader/Province.h
@@ -1,9 +1,11 @@
 #ifndef V3_PROVINCE_H
 #define V3_PROVINCE_H
+#include <memory>
 #include <string>
 
 namespace V3
 {
+struct Chunk;
 class Province
 {
   public:
@@ -11,6 +13,7 @@ class Province
 
 	[[nodiscard]] auto getName() const { return name; }
 	[[nodiscard]] auto getTerrain() const { return terrain; }
+	[[nodiscard]] auto getChunk() const { return chunk; }
 	[[nodiscard]] auto isSea() const { return sea; }
 	[[nodiscard]] auto isLake() const { return lake; }
 	[[nodiscard]] auto isImpassable() const { return impassable; }
@@ -24,6 +27,7 @@ class Province
 	void setImpassable() { impassable = true; }
 	void setName(const std::string& theName) { name = theName; }
 	void setTerrain(const std::string& theTerrain) { terrain = theTerrain; }
+	void setChunk(const std::shared_ptr<Chunk>& theChunk) { chunk = theChunk; }
 
   private:
 	void registerKeys();
@@ -33,6 +37,7 @@ class Province
 	bool sea = false;
 	bool lake = false;
 	bool impassable = false;
+	std::shared_ptr<Chunk> chunk;
 };
 } // namespace V3
 

--- a/EU4toV3/Source/V3World/ClayManager/SubState.h
+++ b/EU4toV3/Source/V3World/ClayManager/SubState.h
@@ -19,6 +19,7 @@ struct SubState
 {
 	std::map<std::string, std::shared_ptr<Province>> provinces; // V3 province codes
 	std::string ownerTag;													// V3 TAG
+	std::string sourceOwnerTag;											// EU4 TAG
 	std::shared_ptr<EU4::Country> sourceOwner;
 	std::shared_ptr<State> state; // home state
 	std::string stateName;

--- a/EU4toV3/Source/V3World/V3World.cpp
+++ b/EU4toV3/Source/V3World/V3World.cpp
@@ -19,6 +19,8 @@ V3::World::World(const Configuration& configuration, const EU4::World& sourceWor
 	clayManager.loadStatesIntoSuperRegions();
 	provinceMapper.loadProvinceMappings("configurables/province_mappings.txt");
 	clayManager.generateChunks(provinceMapper, sourceWorld.getProvinceManager());
+	clayManager.unDisputeChunkOwnership(sourceWorld.getCountryManager().getCountries());
+	clayManager.distributeChunksAcrossSubStates();
 
 	Log(LogLevel::Info) << "*** Hello Vicky 3, creating world. ***";
 	Log(LogLevel::Info) << "-> Importing Provinces";

--- a/EU4toV3Tests/V3WorldTests/ClayManagerTests/ClayManagerTests.cpp
+++ b/EU4toV3Tests/V3WorldTests/ClayManagerTests/ClayManagerTests.cpp
@@ -277,9 +277,15 @@ TEST(V3World_ClayManagerTests, clayManagerCanUndisputeChunkOwnership)
 
 	EXPECT_TRUE(chunk1->sourceOwner);
 	EXPECT_EQ("TAG", chunk1->sourceOwner->getTag());
+	EXPECT_TRUE(chunk1->sourceProvinces.contains(2));
+	EXPECT_TRUE(chunk1->sourceProvinces.contains(3));
+	EXPECT_TRUE(chunk1->provinces.contains("x000003"));
+	EXPECT_TRUE(chunk1->provinces.contains("x000004"));
 
 	EXPECT_TRUE(chunk2->sourceOwner);
 	EXPECT_EQ("GAT", chunk2->sourceOwner->getTag());
+	EXPECT_TRUE(chunk2->sourceProvinces.contains(9));
+	EXPECT_TRUE(chunk2->provinces.contains("x000008"));
 }
 
 TEST(V3World_ClayManagerTests, clayManagerDropsChunksBelongingToInvalidCountries)
@@ -344,10 +350,12 @@ TEST(V3World_ClayManagerTests, clayManagerDropsChunksBelongingToInvalidCountries
 
 	EXPECT_EQ(1, chunks.size());
 
-	const auto& chunk1 = chunks[0]; // land chunk, 2,3->x3,x4
+	const auto& chunk1 = chunks[0]; // land chunk, 9->x8
 
 	EXPECT_TRUE(chunk1->sourceOwner);
 	EXPECT_EQ("GAT", chunk1->sourceOwner->getTag());
+	EXPECT_TRUE(chunk1->sourceProvinces.contains(9));
+	EXPECT_TRUE(chunk1->provinces.contains("x000008"));
 }
 
 TEST(V3World_ClayManagerTests, clayManagerDropsChunksBelongingToInsaneCountries)
@@ -412,10 +420,12 @@ TEST(V3World_ClayManagerTests, clayManagerDropsChunksBelongingToInsaneCountries)
 
 	EXPECT_EQ(1, chunks.size());
 
-	const auto& chunk1 = chunks[0]; // land chunk, 2,3->x3,x4
+	const auto& chunk1 = chunks[0]; // land chunk, 9->x8
 
 	EXPECT_TRUE(chunk1->sourceOwner);
 	EXPECT_EQ("GAT", chunk1->sourceOwner->getTag());
+	EXPECT_TRUE(chunk1->sourceProvinces.contains(9));
+	EXPECT_TRUE(chunk1->provinces.contains("x000008"));
 }
 
 TEST(V3World_ClayManagerTests, clayManagerCanProduceSubstatesFromChunks)

--- a/EU4toV3Tests/V3WorldTests/ClayManagerTests/ClayManagerTests.cpp
+++ b/EU4toV3Tests/V3WorldTests/ClayManagerTests/ClayManagerTests.cpp
@@ -472,7 +472,7 @@ TEST(V3World_ClayManagerTests, clayManagerCanProduceSubstatesFromChunks)
 
 	clayManager.distributeChunksAcrossSubStates();
 
-	const auto& substates = clayManager.getSubstates();
+	const auto& substates = clayManager.getSubStates();
 
 	/*
 	link = { eu4 = 2 eu4 = 3 vic3 = x000003 vic3 = x000004 } #lands->lands // produces substates 1 & 2 since x3 and x4 are in different states.

--- a/EU4toV3Tests/V3WorldTests/ClayManagerTests/ClayManagerTests.cpp
+++ b/EU4toV3Tests/V3WorldTests/ClayManagerTests/ClayManagerTests.cpp
@@ -217,3 +217,279 @@ TEST(V3World_ClayManagerTests, clayManagerCanGenerateSaneChunks)
 	EXPECT_TRUE(chunk3->states.contains("STATE_TEST_LAND4"));
 	EXPECT_EQ(1, chunk3->states.size());
 }
+
+TEST(V3World_ClayManagerTests, clayManagerCanUndisputeChunkOwnership)
+{
+	auto eu4Path = "TestFiles/eu4installation/";
+	EU4::DefaultMapParser defaults;
+	defaults.loadDefaultMap(eu4Path, {});
+	EU4::DefinitionScraper definitions;
+	definitions.loadDefinitions(eu4Path, {});
+	EU4::RegionManager regionMapper;
+	regionMapper.loadRegions(eu4Path, {});
+
+	std::stringstream provinceStream;
+	provinceStream << "-1={}\n";																					// sea, no ownership
+	provinceStream << "-2={ owner = TAG base_tax=10 base_production=10 base_manpower=10 }\n"; // dev 30
+	provinceStream << "-3={ owner = GAT base_tax=1 base_production=1 base_manpower=1 }\n";		// dev 3
+	provinceStream << "-4={}\n";																					// irrelevant
+	provinceStream << "-5={}\n";																					// irrelevant
+	provinceStream << "-6={}\n";																					// irrelevant
+	provinceStream << "-7={}\n";																					// irrelevant
+	provinceStream << "-8={}\n";																					// irrelevant
+	provinceStream << "-9={ owner = GAT base_tax=1 base_production=1 base_manpower=1 }\n";		// dev 3
+	provinceStream << "-10={}\n";																					// irrelevant
+	EU4::ProvinceManager provinceManager;
+	provinceManager.loadProvinces(provinceStream);
+	provinceManager.loadDefaultMapParser(defaults);
+	provinceManager.loadDefinitionScraper(definitions);
+	provinceManager.classifyProvinces(regionMapper);
+	provinceManager.buildProvinceWeights();
+	mappers::ProvinceMapper provinceMapper;
+	provinceMapper.loadProvinceMappings("TestFiles/configurables/province_mappings_chunks.txt");
+	auto V3Path = "TestFiles/vic3installation/game/";
+	V3::ClayManager clayManager;
+	clayManager.initializeVanillaStates(V3Path);
+	clayManager.loadTerrainsIntoProvinces(V3Path);
+	clayManager.initializeSuperRegions(V3Path);
+	clayManager.loadStatesIntoSuperRegions();
+	clayManager.generateChunks(provinceMapper, provinceManager);
+
+	// Wee need some countries to link chunks to.
+	std::stringstream countryStream;
+	const auto tag = std::make_shared<EU4::Country>("TAG", countryStream);
+	const auto gat = std::make_shared<EU4::Country>("GAT", countryStream);
+	std::map<std::string, std::shared_ptr<EU4::Country>> countries = {{"TAG", tag}, {"GAT", gat}};
+
+	clayManager.unDisputeChunkOwnership(countries);
+	const auto& chunks = clayManager.getChunks();
+
+	/*
+	link = { eu4 = 1 vic3 = x000001 vic3 = x000002 } #sea->seas // produces chunk 1 - dropped since no owners
+	link = { eu4 = 2 eu4 = 3 vic3 = x000003 vic3 = x000004 } #lands->lands // produces chunk 2 - goes to TAG due to higher dev.
+	link = { eu4 = 8 eu4 = 9 vic3 = x000008 vic3 = x000009 } # lake,land->land,lake // produces chunk 3, goes to GAT since only owner.
+	*/
+
+	EXPECT_EQ(2, chunks.size());
+
+	const auto& chunk1 = chunks[0]; // land chunk, 2,3->x3,x4
+	const auto& chunk2 = chunks[1]; // land chunk, 9->x8
+
+	EXPECT_TRUE(chunk1->sourceOwner);
+	EXPECT_EQ("TAG", chunk1->sourceOwner->getTag());
+
+	EXPECT_TRUE(chunk2->sourceOwner);
+	EXPECT_EQ("GAT", chunk2->sourceOwner->getTag());
+}
+
+TEST(V3World_ClayManagerTests, clayManagerDropsChunksBelongingToInvalidCountries)
+{
+	auto eu4Path = "TestFiles/eu4installation/";
+	EU4::DefaultMapParser defaults;
+	defaults.loadDefaultMap(eu4Path, {});
+	EU4::DefinitionScraper definitions;
+	definitions.loadDefinitions(eu4Path, {});
+	EU4::RegionManager regionMapper;
+	regionMapper.loadRegions(eu4Path, {});
+
+	std::stringstream provinceStream;
+	provinceStream << "-1={}\n";																					// sea, no ownership
+	provinceStream << "-2={ owner = TAG base_tax=10 base_production=10 base_manpower=10 }\n"; // dev 30
+	provinceStream << "-3={ owner = GAT base_tax=1 base_production=1 base_manpower=1 }\n";		// dev 3
+	provinceStream << "-4={}\n";																					// irrelevant
+	provinceStream << "-5={}\n";																					// irrelevant
+	provinceStream << "-6={}\n";																					// irrelevant
+	provinceStream << "-7={}\n";																					// irrelevant
+	provinceStream << "-8={}\n";																					// irrelevant
+	provinceStream << "-9={ owner = GAT base_tax=1 base_production=1 base_manpower=1 }\n";		// dev 3
+	provinceStream << "-10={}\n";																					// irrelevant
+	EU4::ProvinceManager provinceManager;
+	provinceManager.loadProvinces(provinceStream);
+	provinceManager.loadDefaultMapParser(defaults);
+	provinceManager.loadDefinitionScraper(definitions);
+	provinceManager.classifyProvinces(regionMapper);
+	provinceManager.buildProvinceWeights();
+	mappers::ProvinceMapper provinceMapper;
+	provinceMapper.loadProvinceMappings("TestFiles/configurables/province_mappings_chunks.txt");
+	auto V3Path = "TestFiles/vic3installation/game/";
+	V3::ClayManager clayManager;
+	clayManager.initializeVanillaStates(V3Path);
+	clayManager.loadTerrainsIntoProvinces(V3Path);
+	clayManager.initializeSuperRegions(V3Path);
+	clayManager.loadStatesIntoSuperRegions();
+	clayManager.generateChunks(provinceMapper, provinceManager);
+
+	// Wee need some countries to link chunks to.
+	std::stringstream countryStream;
+	const auto gat = std::make_shared<EU4::Country>("GAT", countryStream);
+	std::map<std::string, std::shared_ptr<EU4::Country>> countries = {{"GAT", gat}};
+
+	std::stringstream log;
+	std::streambuf* cout_buffer = std::cout.rdbuf();
+	std::cout.rdbuf(log.rdbuf());
+
+	clayManager.unDisputeChunkOwnership(countries);
+
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] Chunk owner TAG is invalid. Dropping chunk.)"));
+
+	std::cout.rdbuf(cout_buffer);
+
+	const auto& chunks = clayManager.getChunks();
+
+	/*
+	link = { eu4 = 1 vic3 = x000001 vic3 = x000002 } #sea->seas // produces chunk 1 - dropped since no owners
+	link = { eu4 = 2 eu4 = 3 vic3 = x000003 vic3 = x000004 } #lands->lands // produces chunk 2 - goes to TAG due to higher dev, but there's no TAG so dropped
+	link = { eu4 = 8 eu4 = 9 vic3 = x000008 vic3 = x000009 } # lake,land->land,lake // produces chunk 3, goes to GAT since only owner.
+	*/
+
+	EXPECT_EQ(1, chunks.size());
+
+	const auto& chunk1 = chunks[0]; // land chunk, 2,3->x3,x4
+
+	EXPECT_TRUE(chunk1->sourceOwner);
+	EXPECT_EQ("GAT", chunk1->sourceOwner->getTag());
+}
+
+TEST(V3World_ClayManagerTests, clayManagerDropsChunksBelongingToInsaneCountries)
+{
+	auto eu4Path = "TestFiles/eu4installation/";
+	EU4::DefaultMapParser defaults;
+	defaults.loadDefaultMap(eu4Path, {});
+	EU4::DefinitionScraper definitions;
+	definitions.loadDefinitions(eu4Path, {});
+	EU4::RegionManager regionMapper;
+	regionMapper.loadRegions(eu4Path, {});
+
+	std::stringstream provinceStream;
+	provinceStream << "-1={}\n";																					// sea, no ownership
+	provinceStream << "-2={ owner = TAG base_tax=10 base_production=10 base_manpower=10 }\n"; // dev 30
+	provinceStream << "-3={ owner = GAT base_tax=1 base_production=1 base_manpower=1 }\n";		// dev 3
+	provinceStream << "-4={}\n";																					// irrelevant
+	provinceStream << "-5={}\n";																					// irrelevant
+	provinceStream << "-6={}\n";																					// irrelevant
+	provinceStream << "-7={}\n";																					// irrelevant
+	provinceStream << "-8={}\n";																					// irrelevant
+	provinceStream << "-9={ owner = GAT base_tax=1 base_production=1 base_manpower=1 }\n";		// dev 3
+	provinceStream << "-10={}\n";																					// irrelevant
+	EU4::ProvinceManager provinceManager;
+	provinceManager.loadProvinces(provinceStream);
+	provinceManager.loadDefaultMapParser(defaults);
+	provinceManager.loadDefinitionScraper(definitions);
+	provinceManager.classifyProvinces(regionMapper);
+	provinceManager.buildProvinceWeights();
+	mappers::ProvinceMapper provinceMapper;
+	provinceMapper.loadProvinceMappings("TestFiles/configurables/province_mappings_chunks.txt");
+	auto V3Path = "TestFiles/vic3installation/game/";
+	V3::ClayManager clayManager;
+	clayManager.initializeVanillaStates(V3Path);
+	clayManager.loadTerrainsIntoProvinces(V3Path);
+	clayManager.initializeSuperRegions(V3Path);
+	clayManager.loadStatesIntoSuperRegions();
+	clayManager.generateChunks(provinceMapper, provinceManager);
+
+	// Wee need some countries to link chunks to.
+	std::stringstream countryStream;
+	const auto gat = std::make_shared<EU4::Country>("GAT", countryStream);
+	std::map<std::string, std::shared_ptr<EU4::Country>> countries = {{"TAG", nullptr}, {"GAT", gat}}; // TAG is insane.
+
+	std::stringstream log;
+	std::streambuf* cout_buffer = std::cout.rdbuf();
+	std::cout.rdbuf(log.rdbuf());
+
+	clayManager.unDisputeChunkOwnership(countries);
+
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] Chunk owner TAG is not initialized. Dropping chunk.)"));
+
+	std::cout.rdbuf(cout_buffer);
+
+	const auto& chunks = clayManager.getChunks();
+
+	/*
+	link = { eu4 = 1 vic3 = x000001 vic3 = x000002 } #sea->seas // produces chunk 1 - dropped since no owners
+	link = { eu4 = 2 eu4 = 3 vic3 = x000003 vic3 = x000004 } #lands->lands // produces chunk 2 - goes to TAG due to higher dev, but TAG is insane so dropped
+	link = { eu4 = 8 eu4 = 9 vic3 = x000008 vic3 = x000009 } # lake,land->land,lake // produces chunk 3, goes to GAT since only owner.
+	*/
+
+	EXPECT_EQ(1, chunks.size());
+
+	const auto& chunk1 = chunks[0]; // land chunk, 2,3->x3,x4
+
+	EXPECT_TRUE(chunk1->sourceOwner);
+	EXPECT_EQ("GAT", chunk1->sourceOwner->getTag());
+}
+
+TEST(V3World_ClayManagerTests, clayManagerCanProduceSubstatesFromChunks)
+{
+	auto eu4Path = "TestFiles/eu4installation/";
+	EU4::DefaultMapParser defaults;
+	defaults.loadDefaultMap(eu4Path, {});
+	EU4::DefinitionScraper definitions;
+	definitions.loadDefinitions(eu4Path, {});
+	EU4::RegionManager regionMapper;
+	regionMapper.loadRegions(eu4Path, {});
+
+	std::stringstream provinceStream;
+	provinceStream << "-1={}\n";																					// sea, no ownership
+	provinceStream << "-2={ owner = TAG base_tax=10 base_production=10 base_manpower=10 }\n"; // substate TAG-1&2
+	provinceStream << "-3={ owner = GAT base_tax=1 base_production=1 base_manpower=1 }\n";		// substate TAG-1&2
+	provinceStream << "-4={}\n";																					// irrelevant
+	provinceStream << "-5={}\n";																					// irrelevant
+	provinceStream << "-6={}\n";																					// irrelevant
+	provinceStream << "-7={}\n";																					// irrelevant
+	provinceStream << "-8={}\n";																					// irrelevant
+	provinceStream << "-9={ owner = GAT base_tax=1 base_production=1 base_manpower=1 }\n";		// substate TAG-3
+	provinceStream << "-10={}\n";																					// irrelevant
+	EU4::ProvinceManager provinceManager;
+	provinceManager.loadProvinces(provinceStream);
+	provinceManager.loadDefaultMapParser(defaults);
+	provinceManager.loadDefinitionScraper(definitions);
+	provinceManager.classifyProvinces(regionMapper);
+	provinceManager.buildProvinceWeights();
+	mappers::ProvinceMapper provinceMapper;
+	provinceMapper.loadProvinceMappings("TestFiles/configurables/province_mappings_chunks.txt");
+	auto V3Path = "TestFiles/vic3installation/game/";
+	V3::ClayManager clayManager;
+	clayManager.initializeVanillaStates(V3Path);
+	clayManager.loadTerrainsIntoProvinces(V3Path);
+	clayManager.initializeSuperRegions(V3Path);
+	clayManager.loadStatesIntoSuperRegions();
+	clayManager.generateChunks(provinceMapper, provinceManager);
+	std::stringstream countryStream;
+	const auto tag = std::make_shared<EU4::Country>("TAG", countryStream);
+	const auto gat = std::make_shared<EU4::Country>("GAT", countryStream);
+	std::map<std::string, std::shared_ptr<EU4::Country>> countries = {{"TAG", tag}, {"GAT", gat}};
+	clayManager.unDisputeChunkOwnership(countries);
+
+	clayManager.distributeChunksAcrossSubStates();
+
+	const auto& substates = clayManager.getSubstates();
+
+	/*
+	link = { eu4 = 2 eu4 = 3 vic3 = x000003 vic3 = x000004 } #lands->lands // produces substates 1 & 2 since x3 and x4 are in different states.
+	link = { eu4 = 8 eu4 = 9 vic3 = x000008 vic3 = x000009 } # lake,land->land,lake // produces substate 3, with only x8 inside as x9 is a lake.
+	*/
+
+	EXPECT_EQ(3, substates.size());
+
+	const auto& substate1 = substates[0];
+	const auto& substate2 = substates[1];
+	const auto& substate3 = substates[2];
+
+	EXPECT_TRUE(substate1->sourceOwner);
+	EXPECT_EQ("GAT", substate1->sourceOwner->getTag());
+	EXPECT_EQ(1, substate1->provinces.size());
+	EXPECT_TRUE(substate1->provinces.contains("x000008"));
+	EXPECT_EQ("STATE_TEST_LAND4", substate1->stateName);
+
+	EXPECT_TRUE(substate2->sourceOwner);
+	EXPECT_EQ("TAG", substate2->sourceOwner->getTag());
+	EXPECT_EQ(1, substate2->provinces.size());
+	EXPECT_TRUE(substate2->provinces.contains("x000003"));
+	EXPECT_EQ("STATE_TEST_LAND1", substate2->stateName);
+
+	EXPECT_TRUE(substate3->sourceOwner);
+	EXPECT_EQ("TAG", substate3->sourceOwner->getTag());
+	EXPECT_EQ(1, substate3->provinces.size());
+	EXPECT_TRUE(substate3->provinces.contains("x000004"));
+	EXPECT_EQ("STATE_TEST_LAND2", substate3->stateName);
+}


### PR DESCRIPTION
- Un-disputing chunk ownership - when a chunk is generated from multiple eu4 provinces held by various owners, then the chunk goes to one with highest absolute province weight. This won't affect popratios, demographics will still be shared.
- Undisputed chunks are overlaid across geographical states and their provinces reorganized into substates. Substates are political entities within a geographical state.