### PR TITLE
Infrastructure

### DIFF
--- a/EU4toV3/Source/V3World/ClayManager/ClayMapTypedefs.h
+++ b/EU4toV3/Source/V3World/ClayManager/ClayMapTypedefs.h
@@ -13,10 +13,12 @@ namespace V3
 {
 class SubState;
 class Province;
+class StateModifier;
 using ProvinceMap = std::map<std::string, std::shared_ptr<Province>>;					// v3 province name->v3 province
 using StateToProvinceMap = std::map<std::string, ProvinceMap>;								// state name -> v3 provinces
 using SourceOwners = std::map<std::string, std::shared_ptr<EU4::Country>>;				// eu4tag, eu4country
 using TagSubStates = std::map<std::string, std::vector<std::shared_ptr<SubState>>>; // tag, substate
+using StateModifiers = std::map<std::string, std::shared_ptr<StateModifier>>;			// modifier name -> modifier
 } // namespace V3
 
 #endif // CLAY_MAP_TYPEDEFS_H

--- a/EU4toV3/Source/V3World/ClayManager/State/Province.h
+++ b/EU4toV3/Source/V3World/ClayManager/State/Province.h
@@ -14,6 +14,7 @@ class Province
 	[[nodiscard]] auto getTerrain() const { return terrain; }
 	[[nodiscard]] auto isSea() const { return sea; }
 	[[nodiscard]] auto isLake() const { return lake; }
+	[[nodiscard]] auto isCoastal() const { return coastal; }
 	[[nodiscard]] auto isPrime() const { return prime; }
 	[[nodiscard]] auto isImpassable() const { return impassable; }
 
@@ -23,6 +24,7 @@ class Province
 		lake = true;
 		impassable = true;
 	}
+	void setCoastal() { coastal = true; }
 	void setPrime() { prime = true; }
 	void setImpassable() { impassable = true; }
 	void setName(const std::string& theName) { name = theName; }
@@ -35,6 +37,7 @@ class Province
 	std::string terrain;
 	bool sea = false;
 	bool lake = false;
+	bool coastal = false;
 	bool prime = false;
 	bool impassable = false;
 };

--- a/EU4toV3/Source/V3World/ClayManager/State/StateModifier.cpp
+++ b/EU4toV3/Source/V3World/ClayManager/State/StateModifier.cpp
@@ -27,7 +27,7 @@ void V3::StateModifier::registerKeys()
 		infrastructure = commonItems::getInt(theStream);
 	});
 	registerKeyword("state_infrastructure_mult", [this](std::istream& theStream) {
-		infrastructureModifier = commonItems::getDouble(theStream);
+		infrastructureMult = commonItems::getDouble(theStream);
 	});
 	registerRegex(R"(building_output_\w+_mult)", [this](const std::string& modifierName, std::istream& theStream) {
 		// Goods based throughput modifiers

--- a/EU4toV3/Source/V3World/ClayManager/State/StateModifier.h
+++ b/EU4toV3/Source/V3World/ClayManager/State/StateModifier.h
@@ -14,7 +14,7 @@ class StateModifier: commonItems::parser
 
 	[[nodiscard]] const auto& getName() const { return name; }
 	[[nodiscard]] const auto& getInfrastructureBonus() const { return infrastructure; }
-	[[nodiscard]] const auto& getInfrastructureModifier() const { return infrastructureModifier; }
+	[[nodiscard]] const auto& getInfrastructureMult() const { return infrastructureMult; }
 	[[nodiscard]] const auto& getPortBonus() const { return port; }
 	[[nodiscard]] const auto& getNavalBaseBonus() const { return navalBase; }
 	[[nodiscard]] const auto& getBuildingGroupModifiersMap() const { return buildingGroupModifiers; }
@@ -31,7 +31,7 @@ class StateModifier: commonItems::parser
 	std::string name; // state_trait_natural_harbors
 
 	int infrastructure = 0;
-	double infrastructureModifier = 0.0;
+	double infrastructureMult = 0.0;
 	int port = 0;
 	int navalBase = 0;
 	std::map<std::string, double> buildingGroupModifiers; // building_group to throughput modifier

--- a/EU4toV3/Source/V3World/ClayManager/State/SubState.cpp
+++ b/EU4toV3/Source/V3World/ClayManager/State/SubState.cpp
@@ -57,11 +57,15 @@ void V3::SubState::calculateTerrainFrequency()
 {
 	for (const auto& province: std::views::values(provinces))
 	{
-		terrainFrequency[province->getTerrain()] += 1;
 		if (province->isCoastal())
 		{
-			// By doubling counting provinces as coastal, coastal_mountains are differentiated from coastal_plains
-			terrainFrequency["coastal"] += 1;
+			// Create in effect coastal_mountains, coastal_plains, etc. terrain.
+			terrainFrequency["coastal"] += 0.5;
+			terrainFrequency[province->getTerrain()] += 0.5;
+		}
+		else
+		{
+			terrainFrequency[province->getTerrain()] += 1;
 		}
 	}
 

--- a/EU4toV3/Source/V3World/ClayManager/State/SubState.cpp
+++ b/EU4toV3/Source/V3World/ClayManager/State/SubState.cpp
@@ -6,6 +6,7 @@
 #include "Province.h"
 #include "ProvinceManager/PopRatio.h"
 #include "State.h"
+#include "StateModifier.h"
 #include <cmath>
 #include <numeric>
 #include <ranges>

--- a/EU4toV3/Source/V3World/ClayManager/State/SubState.cpp
+++ b/EU4toV3/Source/V3World/ClayManager/State/SubState.cpp
@@ -90,6 +90,11 @@ std::pair<int, double> V3::SubState::getStateInfrastructureModifiers(const State
 	double mult = 0;
 	for (const auto& stateModifier: getHomeState()->getTraits())
 	{
+		if (!theStateModifiers.contains(stateModifier))
+		{
+			// should never happen
+			continue;
+		}
 		bonus += theStateModifiers.at(stateModifier)->getInfrastructureBonus();
 		mult += theStateModifiers.at(stateModifier)->getInfrastructureMult();
 	}
@@ -98,7 +103,6 @@ std::pair<int, double> V3::SubState::getStateInfrastructureModifiers(const State
 
 void V3::SubState::calculateInfrastructure(const StateModifiers& theStateModifiers)
 {
-	// TODO(Gawquon): Validate stateModifier strings in country are recognized loaded in modifiers.
 	const double popInfra = getPopInfrastructure();
 	auto [stateModBonus, stateModMultipliers] = getStateInfrastructureModifiers(theStateModifiers);
 

--- a/EU4toV3/Source/V3World/ClayManager/State/SubState.cpp
+++ b/EU4toV3/Source/V3World/ClayManager/State/SubState.cpp
@@ -110,9 +110,13 @@ void V3::SubState::calculateInfrastructure(const StateModifiers& theStateModifie
 	const double infraBase = 3 + 2 * isCoastal() + stateModBonus + popInfra;
 
 	// Multipliers are additive, market capital + incorporation status + state modifier multipliers
-	const double multipliers = 0.25 * marketCapital + -0.25 * !incorporated + stateModMultipliers;
+	double multipliers = 0.25 * marketCapital + -0.25 * !incorporated + stateModMultipliers;
+	if (multipliers < -1)
+	{
+		multipliers = -1;
+	}
 
-	infrastructure = infraBase * multipliers;
+	infrastructure = std::max(0.0, infraBase * (1 + multipliers));
 }
 
 void V3::SubState::convertDemographics(const ClayManager& clayManager,

--- a/EU4toV3/Source/V3World/ClayManager/State/SubState.h
+++ b/EU4toV3/Source/V3World/ClayManager/State/SubState.h
@@ -4,7 +4,6 @@
 #include "PopManager/Demographic.h"
 #include "PopManager/Pops/SubStatePops.h"
 #include "SourceProvinceData.h"
-#include "StateModifier.h"
 #include <optional>
 
 /* A Substate is a cross-section across a set of chunks where all relevant chunk provinces fall within a geographical V3 state.
@@ -28,6 +27,7 @@ namespace V3
 class Country;
 class Chunk;
 class State;
+class StateModifier;
 class ClayManager;
 class SubState
 {

--- a/EU4toV3/Source/V3World/ClayManager/State/SubState.h
+++ b/EU4toV3/Source/V3World/ClayManager/State/SubState.h
@@ -58,6 +58,8 @@ class SubState
 
 	void generatePops(int totalAmount);
 
+	void calculateInfrastructure(const StateModifiers& theStateModifiers);
+
 	[[nodiscard]] const auto& getHomeState() const { return homeState; }
 	[[nodiscard]] const auto& getOwner() const { return owner; }
 	[[nodiscard]] const auto& getProvinces() const { return provinces; }
@@ -83,7 +85,8 @@ class SubState
 
   private:
 	void calculateTerrainFrequency();
-	void calculateInfrastructure(const std::map<std::string, std::shared_ptr<StateModifier>>& theStateModifiers);
+	[[nodiscard]] double getPopInfrastructure() const;
+	[[nodiscard]] std::pair<int, double> getStateInfrastructureModifiers(const StateModifiers& theStateModifiers) const;
 
 	std::shared_ptr<State> homeState; // home state
 	std::shared_ptr<Country> owner;

--- a/EU4toV3/Source/V3World/ClayManager/State/SubState.h
+++ b/EU4toV3/Source/V3World/ClayManager/State/SubState.h
@@ -70,6 +70,7 @@ class SubState
 	[[nodiscard]] const auto& getLandshare() const { return landshare; }
 	[[nodiscard]] const auto& getInfrastructure() const { return infrastructure; }
 	[[nodiscard]] const auto& getResource(const std::string& theResource) { return resources[theResource]; }
+	[[nodiscard]] const auto& getTerrainFrequency(const std::string& theTerrain) { return terrainFrequency[theTerrain]; }
 	[[nodiscard]] const auto& getDemographics() const { return demographics; }
 	[[nodiscard]] const auto& getSubStatePops() const { return subStatePops; }
 

--- a/EU4toV3/Source/V3World/ClayManager/State/SubState.h
+++ b/EU4toV3/Source/V3World/ClayManager/State/SubState.h
@@ -44,6 +44,8 @@ class SubState
 	void setWeight(double theWeight) { weight = theWeight; }
 	void setSourceProvinceData(const std::vector<std::pair<SourceProvinceData, double>>& theData) { weightedSourceProvinceData = theData; }
 
+	void setMarketCapital() { marketCapital = true; }
+	void setUnincorporated() { incorporated = false; }
 	void setLandshare(const double theLandshare) { landshare = theLandshare; }
 	void setResource(const std::string& theResource, const int theAmount) { resources[theResource] = theAmount; }
 	void setDemographics(const std::vector<Demographic>& demos) { demographics = demos; }

--- a/EU4toV3/Source/V3World/PoliticalManager/Country/Country.h
+++ b/EU4toV3/Source/V3World/PoliticalManager/Country/Country.h
@@ -67,9 +67,9 @@ class Country: commonItems::parser
 	[[nodiscard]] std::string getAdjective(const std::string& language) const;
 
 	// TODO(Gawquon): Implement, maximum infrastructure that can be created by population according to technology
-	[[nodiscard]] int getTechInfraCap() const { return 40; }
+	[[nodiscard]] int getTechInfraCap() const { return 0; }
 	// TODO(Gawquon): Implement, multiplier for amount of infrastructure created by population
-	[[nodiscard]] double getTechInfraMult() const { return 0.2; }
+	[[nodiscard]] double getTechInfraMult() const { return 0.0; }
 
   private:
 	void registerKeys();

--- a/EU4toV3/Source/V3World/PoliticalManager/Country/Country.h
+++ b/EU4toV3/Source/V3World/PoliticalManager/Country/Country.h
@@ -66,6 +66,11 @@ class Country: commonItems::parser
 	[[nodiscard]] std::string getName(const std::string& language) const;
 	[[nodiscard]] std::string getAdjective(const std::string& language) const;
 
+	// TODO(Gawquon): Implement, maximum infrastructure that can be created by population according to technology
+	[[nodiscard]] int getTechInfraCap() const { return 40; }
+	// TODO(Gawquon): Implement, multiplier for amount of infrastructure created by population
+	[[nodiscard]] double getTechInfraMult() const { return 0.2; }
+
   private:
 	void registerKeys();
 

--- a/EU4toV3Tests/V3WorldTests/ClayManagerTests/StateTests/StateModifierTests.cpp
+++ b/EU4toV3Tests/V3WorldTests/ClayManagerTests/StateTests/StateModifierTests.cpp
@@ -10,7 +10,7 @@ TEST(V3World_StateModifierTests, DefaultsDefaultToDefaults)
 
 	EXPECT_TRUE(modifier.getName().empty());
 	EXPECT_EQ(0, modifier.getInfrastructureBonus());
-	EXPECT_EQ(0, modifier.getInfrastructureModifier());
+	EXPECT_EQ(0, modifier.getInfrastructureMult());
 	EXPECT_EQ(0, modifier.getPortBonus());
 	EXPECT_EQ(0, modifier.getNavalBaseBonus());
 	EXPECT_TRUE(modifier.getBuildingGroupModifiersMap().empty());
@@ -43,7 +43,7 @@ TEST(V3World_StateModifierTests, InfrastructureModifierIsSet)
 	V3::StateModifier modifier;
 	modifier.loadStateModifier(input);
 
-	EXPECT_EQ(-0.4, modifier.getInfrastructureModifier());
+	EXPECT_EQ(-0.4, modifier.getInfrastructureMult());
 }
 
 TEST(V3World_StateModifierTests, PortBonusIsSet)

--- a/EU4toV3Tests/V3WorldTests/ClayManagerTests/StateTests/SubStateTests.cpp
+++ b/EU4toV3Tests/V3WorldTests/ClayManagerTests/StateTests/SubStateTests.cpp
@@ -1,4 +1,5 @@
 #include "ClayManager/ClayManager.h"
+#include "ClayManager/State/Province.h"
 #include "ClayManager/State/State.h"
 #include "ClayManager/State/SubState.h"
 #include "CultureLoader/CultureLoader.h"
@@ -8,8 +9,6 @@
 #include "ReligionLoader/ReligionLoader.h"
 #include "gtest/gtest.h"
 #include <gmock/gmock-matchers.h>
-
-#include "ClayManager/State/Province.h"
 
 TEST(V3World_SubStateTests, OwnerTagCanBeSetAndRetrieved)
 {

--- a/EU4toV3Tests/V3WorldTests/ClayManagerTests/StateTests/SubStateTests.cpp
+++ b/EU4toV3Tests/V3WorldTests/ClayManagerTests/StateTests/SubStateTests.cpp
@@ -163,9 +163,9 @@ TEST(V3World_SubStateTests, coastalFlagCountsAsTerrain)
 	const V3::ProvinceMap provinces{{p0->getName(), p0}, {p1->getName(), p1}, {p2->getName(), p2}};
 	substate.setProvinces(provinces);
 
-	EXPECT_DOUBLE_EQ(1.0 / 4, substate.getTerrainFrequency("desert"));
-	EXPECT_DOUBLE_EQ(2.0 / 4, substate.getTerrainFrequency("plains"));
-	EXPECT_DOUBLE_EQ(1.0 / 4, substate.getTerrainFrequency("coastal"));
+	EXPECT_DOUBLE_EQ(0.5 / 3, substate.getTerrainFrequency("desert"));
+	EXPECT_DOUBLE_EQ(2.0 / 3, substate.getTerrainFrequency("plains"));
+	EXPECT_DOUBLE_EQ(0.5 / 3, substate.getTerrainFrequency("coastal"));
 }
 
 TEST(V3World_SubStateTests, InfrastructureCalculationIsolateStateModifieres)

--- a/EU4toV3Tests/V3WorldTests/ClayManagerTests/StateTests/SubStateTests.cpp
+++ b/EU4toV3Tests/V3WorldTests/ClayManagerTests/StateTests/SubStateTests.cpp
@@ -9,6 +9,8 @@
 #include "gtest/gtest.h"
 #include <gmock/gmock-matchers.h>
 
+#include "ClayManager/State/Province.h"
+
 TEST(V3World_SubStateTests, OwnerTagCanBeSetAndRetrieved)
 {
 	V3::SubState subState;
@@ -120,4 +122,48 @@ TEST(V3World_SubStateTests, SubStateCanGeneratePopsFromDemographics)
 	EXPECT_EQ("cul2", pop2.getCulture());
 	EXPECT_EQ("rel2", pop2.getReligion());
 	EXPECT_EQ(700, pop2.getSize());
+}
+
+TEST(V3World_SubStateTests, TerrainFrequencyNormalizes)
+{
+	auto substate = V3::SubState();
+
+	auto p0 = std::make_shared<V3::Province>();
+	p0->setName("x112233");
+	p0->setTerrain("desert");
+	auto p1 = std::make_shared<V3::Province>();
+	p1->setName("x445566");
+	p1->setTerrain("plains");
+	auto p2 = std::make_shared<V3::Province>();
+	p2->setName("x778899");
+	p2->setTerrain("plains");
+
+	const V3::ProvinceMap provinces{{p0->getName(), p0}, {p1->getName(), p1}, {p2->getName(), p2}};
+	substate.setProvinces(provinces);
+
+	EXPECT_DOUBLE_EQ(1.0 / 3, substate.getTerrainFrequency("desert"));
+	EXPECT_DOUBLE_EQ(2.0 / 3, substate.getTerrainFrequency("plains"));
+}
+
+TEST(V3World_SubStateTests, coastalFlagCountsAsTerrain)
+{
+	auto substate = V3::SubState();
+
+	auto p0 = std::make_shared<V3::Province>();
+	p0->setName("x112233");
+	p0->setTerrain("desert");
+	p0->setCoastal();
+	auto p1 = std::make_shared<V3::Province>();
+	p1->setName("x445566");
+	p1->setTerrain("plains");
+	auto p2 = std::make_shared<V3::Province>();
+	p2->setName("x778899");
+	p2->setTerrain("plains");
+
+	const V3::ProvinceMap provinces{{p0->getName(), p0}, {p1->getName(), p1}, {p2->getName(), p2}};
+	substate.setProvinces(provinces);
+
+	EXPECT_DOUBLE_EQ(1.0 / 4, substate.getTerrainFrequency("desert"));
+	EXPECT_DOUBLE_EQ(2.0 / 4, substate.getTerrainFrequency("plains"));
+	EXPECT_DOUBLE_EQ(1.0 / 4, substate.getTerrainFrequency("coastal"));
 }


### PR DESCRIPTION
calculate infrastructure on a substate level, needed for knowing when to build ports and rails. Tells us how much industry a substate can support and while we should usually not be approaching this number some infrastructure light states might.