### PR TITLE
Colonial tag replacement

### DIFF
--- a/EU4toV3/EU4ToV3.vcxproj
+++ b/EU4toV3/EU4ToV3.vcxproj
@@ -130,6 +130,8 @@ call save_commit_id.bat</Command>
     <ClCompile Include="Source\Mappers\CharacterTraitMapper\SkillMapping.cpp" />
     <ClCompile Include="Source\Mappers\ColonialRegionMapper\ColonialRegionMapper.cpp" />
     <ClCompile Include="Source\Mappers\ColonialRegionMapper\ColonialRegionMapping.cpp" />
+    <ClCompile Include="Source\Mappers\ColonialTagMapper\ColonialTagMapper.cpp" />
+    <ClCompile Include="Source\Mappers\ColonialTagMapper\ColonialTagMapping.cpp" />
     <ClCompile Include="Source\Mappers\CountryMapper\CountryMapper.cpp" />
     <ClCompile Include="Source\Mappers\CountryMapper\CountryMapping.cpp" />
     <ClCompile Include="Source\Mappers\CultureMapper\CultureDefinitionLoader\CultureDefinitionEntry.cpp" />
@@ -306,6 +308,8 @@ call save_commit_id.bat</Command>
     <ClInclude Include="Source\Mappers\CharacterTraitMapper\SkillMapping.h" />
     <ClInclude Include="Source\Mappers\ColonialRegionMapper\ColonialRegionMapper.h" />
     <ClInclude Include="Source\Mappers\ColonialRegionMapper\ColonialRegionMapping.h" />
+    <ClInclude Include="Source\Mappers\ColonialTagMapper\ColonialTagMapper.h" />
+    <ClInclude Include="Source\Mappers\ColonialTagMapper\ColonialTagMapping.h" />
     <ClInclude Include="Source\Mappers\CountryMapper\CountryMapper.h" />
     <ClInclude Include="Source\Mappers\CountryMapper\CountryMapping.h" />
     <ClInclude Include="Source\Mappers\CultureMapper\CultureDefinitionLoader\CultureDef.h" />

--- a/EU4toV3/EU4ToV3.vcxproj.filters
+++ b/EU4toV3/EU4ToV3.vcxproj.filters
@@ -498,6 +498,12 @@
     <ClCompile Include="Source\Output\outCoAs\outCoAa.cpp">
       <Filter>Output\outCoAs</Filter>
     </ClCompile>
+    <ClCompile Include="Source\Mappers\ColonialTagMapper\ColonialTagMapper.cpp">
+      <Filter>Mappers\ColonialTagMapper</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\Mappers\ColonialTagMapper\ColonialTagMapping.cpp">
+      <Filter>Mappers\ColonialTagMapper</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\EU4ToVic3Converter.h" />
@@ -1053,6 +1059,12 @@
     <ClInclude Include="Source\Output\outCoAs\outCoAa.h">
       <Filter>Output\outCoAs</Filter>
     </ClInclude>
+    <ClInclude Include="Source\Mappers\ColonialTagMapper\ColonialTagMapper.h">
+      <Filter>Mappers\ColonialTagMapper</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\Mappers\ColonialTagMapper\ColonialTagMapping.h">
+      <Filter>Mappers\ColonialTagMapper</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="EU4World">
@@ -1309,6 +1321,9 @@
     </Filter>
     <Filter Include="Output\outCoAs">
       <UniqueIdentifier>{6f16da54-3f79-4ba2-aee6-b0548f7edb9e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Mappers\ColonialTagMapper">
+      <UniqueIdentifier>{0434a418-4994-4fcf-8a82-419fafc876a4}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/EU4toV3/Source/Mappers/ColonialTagMapper/ColonialTagMapper.cpp
+++ b/EU4toV3/Source/Mappers/ColonialTagMapper/ColonialTagMapper.cpp
@@ -11,7 +11,7 @@ void mappers::ColonialTagMapper::loadMappingRules(const std::string& filePath)
 	registerKeys();
 	parseFile(filePath);
 	clearRegisteredKeywords();
-	Log(LogLevel::Info) << "<> " << colonialTagMappings.size() << " rules loaded.";
+	Log(LogLevel::Info) << "<> " << colonialTagMappings.size() << " colonial tag rules loaded.";
 }
 
 void mappers::ColonialTagMapper::registerKeys()

--- a/EU4toV3/Source/Mappers/ColonialTagMapper/ColonialTagMapper.cpp
+++ b/EU4toV3/Source/Mappers/ColonialTagMapper/ColonialTagMapper.cpp
@@ -1,0 +1,33 @@
+#include "ColonialTagMapper.h"
+#include "ClayManager/ClayManager.h"
+#include "CommonRegexes.h"
+#include "Log.h"
+#include "ParserHelpers.h"
+#include <ranges>
+
+void mappers::ColonialTagMapper::loadMappingRules(const std::string& filePath)
+{
+	Log(LogLevel::Info) << "-> Loading colonial tag mapping rules.";
+	registerKeys();
+	parseFile(filePath);
+	clearRegisteredKeywords();
+	Log(LogLevel::Info) << "<> " << colonialTagMappings.size() << " rules loaded.";
+}
+
+void mappers::ColonialTagMapper::registerKeys()
+{
+	registerKeyword("link", [this](std::istream& theStream) {
+		colonialTagMappings.emplace_back(ColonialTagMapping(theStream));
+	});
+	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
+}
+
+std::optional<std::string> mappers::ColonialTagMapper::matchColonialTag(const V3::Country& country,
+	 const ColonialRegionMapper& colonialRegionMapper,
+	 const V3::ClayManager& clayManager) const
+{
+	for (const auto& mapping: colonialTagMappings)
+		if (const auto& match = mapping.matchColonialTag(country, colonialRegionMapper, clayManager); match)
+			return match;
+	return std::nullopt;
+}

--- a/EU4toV3/Source/Mappers/ColonialTagMapper/ColonialTagMapper.h
+++ b/EU4toV3/Source/Mappers/ColonialTagMapper/ColonialTagMapper.h
@@ -1,0 +1,29 @@
+#ifndef COLONIAL_TAG_MAPPER_H
+#define COLONIAL_TAG_MAPPER_H
+#include "ColonialTagMapping.h"
+#include "Parser.h"
+
+namespace V3
+{
+class ClayManager;
+}
+namespace mappers
+{
+class ColonialTagMapper: commonItems::parser
+{
+  public:
+	ColonialTagMapper() = default;
+	void loadMappingRules(const std::string& filePath);
+
+	[[nodiscard]] std::optional<std::string> matchColonialTag(const V3::Country& country,
+		 const ColonialRegionMapper& colonialRegionMapper,
+		 const V3::ClayManager& clayManager) const;
+
+  private:
+	void registerKeys();
+
+	std::vector<ColonialTagMapping> colonialTagMappings;
+};
+} // namespace mappers
+
+#endif // COLONIAL_TAG_MAPPER_H

--- a/EU4toV3/Source/Mappers/ColonialTagMapper/ColonialTagMapping.cpp
+++ b/EU4toV3/Source/Mappers/ColonialTagMapper/ColonialTagMapping.cpp
@@ -35,13 +35,18 @@ std::optional<std::string> mappers::ColonialTagMapping::matchColonialTag(const V
 	const auto& subStates = country.getSubStates();
 	if (subStates.empty())
 		return std::nullopt;
+
 	const auto& capitalStateName = country.getProcessedData().capitalStateName;
 	if (capitalStateName.empty() && !tag.empty())
 		return std::nullopt;
 
 	// first the capital matches
-	if (!tag.empty() && capitalStateName == region)
-		return tag;
+	if (!tag.empty())
+	{
+		if (capitalStateName == region)
+			return tag;
+		return std::nullopt;
+	}
 
 	if (aloneName.empty())
 	{
@@ -75,5 +80,6 @@ std::optional<std::string> mappers::ColonialTagMapping::matchColonialTag(const V
 	for (const auto& requiredState: requiredStates)
 		if (!ownedStates.contains(requiredState))
 			return std::nullopt;
+
 	return aloneName;
 }

--- a/EU4toV3/Source/Mappers/ColonialTagMapper/ColonialTagMapping.cpp
+++ b/EU4toV3/Source/Mappers/ColonialTagMapper/ColonialTagMapping.cpp
@@ -1,0 +1,79 @@
+#include "ColonialTagMapping.h"
+#include "ClayManager/ClayManager.h"
+#include "ClayManager/State/SubState.h"
+#include "ColonialRegionMapper/ColonialRegionMapper.h"
+#include "CommonRegexes.h"
+#include "Log.h"
+#include "ParserHelpers.h"
+#include "PoliticalManager/Country/Country.h"
+
+mappers::ColonialTagMapping::ColonialTagMapping(std::istream& theStream)
+{
+	registerKeys();
+	parseStream(theStream);
+	clearRegisteredKeywords();
+}
+
+void mappers::ColonialTagMapping::registerKeys()
+{
+	registerKeyword("region", [this](std::istream& theStream) {
+		region = commonItems::getString(theStream);
+	});
+	registerKeyword("alone", [this](std::istream& theStream) {
+		aloneName = commonItems::getString(theStream);
+	});
+	registerKeyword("tag", [this](std::istream& theStream) {
+		tag = commonItems::getString(theStream);
+	});
+	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
+}
+
+std::optional<std::string> mappers::ColonialTagMapping::matchColonialTag(const V3::Country& country,
+	 const ColonialRegionMapper& colonialRegionMapper,
+	 const V3::ClayManager& clayManager) const
+{
+	const auto& subStates = country.getSubStates();
+	if (subStates.empty())
+		return std::nullopt;
+	const auto& capitalStateName = country.getProcessedData().capitalStateName;
+	if (capitalStateName.empty() && !tag.empty())
+		return std::nullopt;
+
+	// first the capital matches
+	if (!tag.empty() && capitalStateName == region)
+		return tag;
+
+	if (aloneName.empty())
+	{
+		Log(LogLevel::Warning) << "There is an error with " << region << " mapping in colonial_tags.txt. No alone entry.";
+		return std::nullopt;
+	}
+
+	// then the whole region match.
+	const auto& colonialRegions = colonialRegionMapper.getColonialRegions();
+	if (!colonialRegions.contains(region))
+	{
+		Log(LogLevel::Warning) << "Attempting to colonial region match " << region << " which isn't defined in colonial_regions.txt!";
+		return std::nullopt;
+	}
+
+	// what is required
+	const auto& requiredRegions = colonialRegions.at(region).getRegions();
+	std::set<std::string> requiredStates;
+	for (const auto& theRegion: requiredRegions)
+	{
+		auto states = clayManager.getStateNamesForRegion(theRegion);
+		requiredStates.insert(states.begin(), states.end());
+	}
+
+	// what is owned
+	std::set<std::string> ownedStates;
+	for (const auto& state: country.getSubStates())
+		ownedStates.emplace(state->getHomeStateName());
+
+	// do we have presence in each of the required states? No need to check for 100% ownership, presence is sufficient.
+	for (const auto& requiredState: requiredStates)
+		if (!ownedStates.contains(requiredState))
+			return std::nullopt;
+	return aloneName;
+}

--- a/EU4toV3/Source/Mappers/ColonialTagMapper/ColonialTagMapping.h
+++ b/EU4toV3/Source/Mappers/ColonialTagMapper/ColonialTagMapping.h
@@ -1,0 +1,32 @@
+#ifndef COLONIAL_TAG_MAPPING_H
+#define COLONIAL_TAG_MAPPING_H
+#include "Parser.h"
+
+namespace V3
+{
+class Country;
+class ClayManager;
+} // namespace V3
+namespace mappers
+{
+class ColonialRegionMapper;
+class ColonialTagMapping: commonItems::parser
+{
+  public:
+	ColonialTagMapping() = default;
+	explicit ColonialTagMapping(std::istream& theStream);
+
+	[[nodiscard]] std::optional<std::string> matchColonialTag(const V3::Country& country,
+		 const ColonialRegionMapper& colonialRegionMapper,
+		 const V3::ClayManager& clayManager) const;
+
+  private:
+	void registerKeys();
+
+	std::string region;
+	std::string aloneName;
+	std::string tag;
+};
+} // namespace mappers
+
+#endif // COLONIAL_TAG_MAPPING_H

--- a/EU4toV3/Source/Mappers/CountryMapper/CountryMapper.cpp
+++ b/EU4toV3/Source/Mappers/CountryMapper/CountryMapper.cpp
@@ -197,3 +197,18 @@ std::string mappers::CountryMapper::requestNewV3Tag()
 	unmappedV3Tags.emplace(newTag);
 	return newTag;
 }
+
+void mappers::CountryMapper::relink(const std::string& eu4tag, const std::string& currentTag, const std::string& newTag)
+{
+	if (!eu4TagToV3TagMap.contains(eu4tag))
+		Log(LogLevel::Error) << "Relinking eu4 tag " + eu4tag + " failed, it was never linked!";
+
+	eu4TagToV3TagMap.at(eu4tag) = newTag;
+	v3TagToEU4TagMap.erase(currentTag);
+	v3TagToEU4TagMap.emplace(newTag, eu4tag);
+	if (v3FlagCodes.contains(currentTag))
+	{
+		v3FlagCodes.emplace(newTag, v3FlagCodes.at(currentTag));
+		v3FlagCodes.erase(currentTag);
+	}
+}

--- a/EU4toV3/Source/Mappers/CountryMapper/CountryMapper.h
+++ b/EU4toV3/Source/Mappers/CountryMapper/CountryMapper.h
@@ -30,6 +30,8 @@ class CountryMapper: commonItems::parser
 
 	[[nodiscard]] const auto& getMappingRules() const { return countryMappingRules; }
 
+	void relink(const std::string& eu4tag, const std::string& currentTag, const std::string& newTag);
+
   private:
 	void registerKeys();
 

--- a/EU4toV3/Source/Mappers/CultureMapper/CultureMapper.h
+++ b/EU4toV3/Source/Mappers/CultureMapper/CultureMapper.h
@@ -44,6 +44,8 @@ class CultureMapper: commonItems::parser
 	[[nodiscard]] const auto& getUsedCultures() const { return usedCultures; }
 	[[nodiscard]] const auto& getV3CultureDefinitions() const { return v3CultureDefinitions; }
 
+	[[nodiscard]] const auto& getColonialRegionMapper() const { return colonialRegionMapper; }
+
 	[[nodiscard]] std::optional<std::string> cultureMatch(const V3::ClayManager& clayManager,
 		 const EU4::CultureLoader& cultureLoader,
 		 const EU4::ReligionLoader& religionLoader,

--- a/EU4toV3/Source/Output/outLocalizations/outLocalizations.cpp
+++ b/EU4toV3/Source/Output/outLocalizations/outLocalizations.cpp
@@ -1,9 +1,12 @@
 #include "outLocalizations.h"
 #include "CommonFunctions.h"
+#include "Loaders/LocLoader/LocalizationLoader.h"
 #include <fstream>
 #include <ranges>
 
-void OUT::exportCountryNamesAndAdjectives(const std::string& outputName, const std::map<std::string, std::shared_ptr<V3::Country>>& countries)
+void OUT::exportCountryNamesAndAdjectives(const std::string& outputName,
+	 const std::map<std::string, std::shared_ptr<V3::Country>>& countries,
+	 const V3::LocalizationLoader& knownLocs)
 {
 	const std::set<std::string> knownVic3Localizations =
 		 {"braz_por", "english", "french", "german", "japanese", "korean", "polish", "russian", "simp_chinese", "spanish", "turkish"};
@@ -17,14 +20,18 @@ void OUT::exportCountryNamesAndAdjectives(const std::string& outputName, const s
 		output << commonItems::utf8BOM << "l_" << language << ":\n";
 		for (const auto& country: countries | std::views::values)
 		{
-			output << " " << country->getTag() << ": \"" << country->getName(language) << "\"\n";
-			output << " " << country->getTag() << "_ADJ: \"" << country->getAdjective(language) << "\"\n";
+			if (!knownLocs.getLocMapForKey(country->getTag()))
+				output << " " << country->getTag() << ": \"" << country->getName(language) << "\"\n";
+			if (!knownLocs.getLocMapForKey(country->getTag() + "_ADJ"))
+				output << " " << country->getTag() << "_ADJ: \"" << country->getAdjective(language) << "\"\n";
 		}
 		output.close();
 	}
 }
 
-void OUT::exportCharacterLocs(const std::string& outputName, const std::map<std::string, std::shared_ptr<V3::Country>>& countries)
+void OUT::exportCharacterLocs(const std::string& outputName,
+	 const std::map<std::string, std::shared_ptr<V3::Country>>& countries,
+	 const V3::LocalizationLoader& knownLocs)
 {
 	const std::set<std::string> knownVic3Localizations =
 		 {"braz_por", "english", "french", "german", "japanese", "korean", "polish", "russian", "simp_chinese", "spanish", "turkish"};
@@ -39,12 +46,15 @@ void OUT::exportCharacterLocs(const std::string& outputName, const std::map<std:
 		for (const auto& country: countries | std::views::values)
 			for (const auto& character: country->getProcessedData().characters)
 				for (const auto& [key, loc]: character.localizations)
-					output << " " << key << ": \"" << loc << "\"\n";
+					if (!knownLocs.getLocMapForKey(key))
+						output << " " << key << ": \"" << loc << "\"\n";
 		output.close();
 	}
 }
 
-void OUT::exportReligionLocs(const std::string& outputName, const std::map<std::string, mappers::ReligionDef>& religions)
+void OUT::exportReligionLocs(const std::string& outputName,
+	 const std::map<std::string, mappers::ReligionDef>& religions,
+	 const V3::LocalizationLoader& knownLocs)
 {
 	const std::set<std::string> knownVic3Localizations =
 		 {"braz_por", "english", "french", "german", "japanese", "korean", "polish", "russian", "simp_chinese", "spanish", "turkish"};
@@ -58,16 +68,19 @@ void OUT::exportReligionLocs(const std::string& outputName, const std::map<std::
 		output << commonItems::utf8BOM << "l_" << language << ":\n";
 		for (const auto& religion: religions | std::views::values)
 		{
-			if (religion.locBlock.contains(language))
-				output << " " << religion.name << ": \"" << religion.locBlock.at(language) << "\"\n";
-			else if (religion.locBlock.contains("english"))
-				output << " " << religion.name << ": \"" << religion.locBlock.at("english") << "\"\n";
+			if (!knownLocs.getLocMapForKey(religion.name))
+			{
+				if (religion.locBlock.contains(language))
+					output << " " << religion.name << ": \"" << religion.locBlock.at(language) << "\"\n";
+				else if (religion.locBlock.contains("english"))
+					output << " " << religion.name << ": \"" << religion.locBlock.at("english") << "\"\n";
+			}
 		}
 		output.close();
 	}
 }
 
-void OUT::exportCultureLocs(const std::string& outputName, const std::map<std::string, mappers::CultureDef>& cultures)
+void OUT::exportCultureLocs(const std::string& outputName, const std::map<std::string, mappers::CultureDef>& cultures, const V3::LocalizationLoader& knownLocs)
 {
 	const std::set<std::string> knownVic3Localizations =
 		 {"braz_por", "english", "french", "german", "japanese", "korean", "polish", "russian", "simp_chinese", "spanish", "turkish"};
@@ -87,13 +100,16 @@ void OUT::exportCultureLocs(const std::string& outputName, const std::map<std::s
 		names << commonItems::utf8BOM << "l_" << language << ":\n";
 		for (const auto& culture: cultures | std::views::values)
 		{
-			if (culture.locBlock.contains(language))
-				output << " " << culture.name << ": \"" << culture.locBlock.at(language) << "\"\n";
-			else if (culture.locBlock.contains("english"))
-				output << " " << culture.name << ": \"" << culture.locBlock.at("english") << "\"\n";
+			if (!knownLocs.getLocMapForKey(culture.name))
+			{
+				if (culture.locBlock.contains(language))
+					output << " " << culture.name << ": \"" << culture.locBlock.at(language) << "\"\n";
+				else if (culture.locBlock.contains("english"))
+					output << " " << culture.name << ": \"" << culture.locBlock.at("english") << "\"\n";
+			}
 			for (const auto& [name, locName]: culture.nameLocBlock)
 			{
-				if (!seenNames.contains(name))
+				if (!seenNames.contains(name) && !knownLocs.getLocMapForKey(name))
 				{
 					names << " " << name << ": \"" << locName << "\"\n";
 					seenNames.emplace(name);

--- a/EU4toV3/Source/Output/outLocalizations/outLocalizations.h
+++ b/EU4toV3/Source/Output/outLocalizations/outLocalizations.h
@@ -6,10 +6,14 @@
 
 namespace OUT
 {
-void exportCountryNamesAndAdjectives(const std::string& outputName, const std::map<std::string, std::shared_ptr<V3::Country>>& countries);
-void exportReligionLocs(const std::string& outputName, const std::map<std::string, mappers::ReligionDef>& religions);
-void exportCultureLocs(const std::string& outputName, const std::map<std::string, mappers::CultureDef>& cultures);
-void exportCharacterLocs(const std::string& outputName, const std::map<std::string, std::shared_ptr<V3::Country>>& countries);
+void exportCountryNamesAndAdjectives(const std::string& outputName,
+	 const std::map<std::string, std::shared_ptr<V3::Country>>& countries,
+	 const V3::LocalizationLoader& knownLocs);
+void exportReligionLocs(const std::string& outputName, const std::map<std::string, mappers::ReligionDef>& religions, const V3::LocalizationLoader& knownLocs);
+void exportCultureLocs(const std::string& outputName, const std::map<std::string, mappers::CultureDef>& cultures, const V3::LocalizationLoader& knownLocs);
+void exportCharacterLocs(const std::string& outputName,
+	 const std::map<std::string, std::shared_ptr<V3::Country>>& countries,
+	 const V3::LocalizationLoader& knownLocs);
 
 } // namespace OUT
 

--- a/EU4toV3/Source/Output/outWorld.cpp
+++ b/EU4toV3/Source/Output/outWorld.cpp
@@ -17,6 +17,7 @@
 void OUT::exportWorld(const Configuration& configuration, const V3::World& world, const commonItems::ConverterVersion& converterVersion)
 {
 	const auto& outputName = configuration.getOutputName();
+	const auto& knownLocs = world.getVanillaLocalizations();
 
 	Log(LogLevel::Info) << "---> Le Dump <---";
 
@@ -79,10 +80,10 @@ void OUT::exportWorld(const Configuration& configuration, const V3::World& world
 	Log(LogLevel::Progress) << "90 %";
 
 	Log(LogLevel::Info) << "<- Writing Localizations";
-	exportCountryNamesAndAdjectives(outputName, world.getPoliticalManager().getCountries());
-	exportReligionLocs(outputName, world.getReligionMapper().getV3ReligionDefinitions());
-	exportCultureLocs(outputName, world.getCultureMapper().getV3CultureDefinitions());
-	exportCharacterLocs(outputName, world.getPoliticalManager().getCountries());
+	exportCountryNamesAndAdjectives(outputName, world.getPoliticalManager().getCountries(), knownLocs);
+	exportReligionLocs(outputName, world.getReligionMapper().getV3ReligionDefinitions(), knownLocs);
+	exportCultureLocs(outputName, world.getCultureMapper().getV3CultureDefinitions(), knownLocs);
+	exportCharacterLocs(outputName, world.getPoliticalManager().getCountries(), knownLocs);
 	Log(LogLevel::Progress) << "91 %";
 
 	Log(LogLevel::Info) << "<- Writing Provinces";

--- a/EU4toV3/Source/V3World/ClayManager/ClayManager.cpp
+++ b/EU4toV3/Source/V3World/ClayManager/ClayManager.cpp
@@ -701,3 +701,34 @@ std::optional<std::string> V3::ClayManager::getHistoricalCapitalState(const std:
 			return substate->getHomeStateName();
 	return std::nullopt;
 }
+
+std::set<std::string> V3::ClayManager::getStateNamesForRegion(const std::string& regionName) const
+{
+	std::set<std::string> stateNames;
+	if (states.contains(regionName))
+	{
+		stateNames.emplace(regionName);
+		return stateNames;
+	}
+
+	if (superRegions.contains(regionName))
+	{
+		for (const auto& region: superRegions.at(regionName)->getRegions() | std::views::values)
+			for (const auto& state: region->getStates() | std::views::keys)
+				stateNames.emplace(state);
+		return stateNames;
+	}
+
+	for (const auto& superRegion: superRegions | std::views::values)
+	{
+		if (superRegion->getRegions().contains(regionName))
+		{
+			for (const auto& state: superRegion->getRegions().at(regionName)->getStates() | std::views::keys)
+				stateNames.emplace(state);
+			return stateNames;
+		}
+	}
+
+	Log(LogLevel::Warning) << "Attempting colonial lookup at " << regionName << " failed! It doesn't match anything we know!";
+	return stateNames;
+}

--- a/EU4toV3/Source/V3World/ClayManager/ClayManager.h
+++ b/EU4toV3/Source/V3World/ClayManager/ClayManager.h
@@ -52,6 +52,7 @@ class ClayManager
 	[[nodiscard]] bool regionIsValid(const std::string& region) const;
 	[[nodiscard]] bool stateIsInRegion(const std::string& state, const std::string& region) const;
 	[[nodiscard]] std::optional<std::string> getHistoricalCapitalState(const std::string& eu4tag) const;
+	[[nodiscard]] std::set<std::string> getStateNamesForRegion(const std::string& regionName) const;
 
   private:
 	[[nodiscard]] std::vector<std::shared_ptr<SubState>> chunkToSubStatesTransferFunction(const std::shared_ptr<Chunk>& chunk) const;

--- a/EU4toV3/Source/V3World/PoliticalManager/PoliticalManager.h
+++ b/EU4toV3/Source/V3World/PoliticalManager/PoliticalManager.h
@@ -1,6 +1,7 @@
 #ifndef POLITICAL_MANAGER_H
 #define POLITICAL_MANAGER_H
 #include "CharacterTraitMapper/CharacterTraitMapper.h"
+#include "ColonialTagMapper/ColonialTagMapper.h"
 #include "Configuration.h"
 #include "DatingData.h"
 #include "Diplomacy/Agreement.h"
@@ -53,6 +54,7 @@ class PoliticalManager
 	void loadLawDefinitions(const commonItems::ModFilesystem& modFS);
 	void loadDiplomaticMapperRules(const std::string& filePath);
 	void loadCharacterTraitMapperRules(const std::string& filePath);
+	void loadColonialTagMapperRules(const std::string& filePath);
 	void importEU4Countries(const std::map<std::string, std::shared_ptr<EU4::Country>>& eu4Countries);
 	void generateDecentralizedCountries(const ClayManager& clayManager, const PopManager& popManager);
 	void convertAllCountries(const ClayManager& clayManager,
@@ -85,12 +87,16 @@ class PoliticalManager
 		 const EU4::CultureLoader& cultureLoader,
 		 const EU4::ReligionLoader& religionLoader);
 
+	void attemptColonialTagReplacement(const mappers::ColonialRegionMapper& colonialRegionMapper, const ClayManager& clayManager);
+
   private:
 	void generateDecentralizedCountry(const std::string& culture, const std::vector<std::shared_ptr<SubState>>& subStates);
 	static CulturalSubStates sortSubStatesByCultures(const ClayManager& clayManager, const PopManager& popManager);
 	static std::string getDominantDemographic(const std::vector<Demographic>& demographics);
 	void grantLawFromGroup(const std::string& lawGroup, const std::shared_ptr<Country>& country) const;
 	[[nodiscard]] bool isEU4CountryConvertedAndLanded(const std::string& eu4Tag) const;
+	[[nodiscard]] bool isValidForColonialReplacement(const std::string& tag) const;
+	void changeTag(const std::string& replacement, const std::string& tag);
 
 	std::map<std::string, std::shared_ptr<Country>> countries;
 	std::vector<Agreement> agreements;
@@ -102,6 +108,7 @@ class PoliticalManager
 	mappers::LawMapper lawMapper;
 	mappers::DiplomaticMapper diplomaticMapper;
 	mappers::CharacterTraitMapper characterTraitMapper;
+	mappers::ColonialTagMapper colonialTagMapper;
 };
 } // namespace V3
 #endif // POLITICAL_MANAGER_H

--- a/EU4toV3/Source/V3World/V3World.cpp
+++ b/EU4toV3/Source/V3World/V3World.cpp
@@ -11,6 +11,9 @@ V3::World::World(const Configuration& configuration, const EU4::World& sourceWor
 	const auto dwFS = commonItems::ModFilesystem(V3Path, overrideMods);
 	overrideMods.emplace_back(Mod{"Blankmod", "blankMod/output/"});
 	const auto allFS = commonItems::ModFilesystem(V3Path, overrideMods);
+	overrideMods.clear();
+	overrideMods.emplace_back(Mod{"Blankmod", "blankMod/output/"});
+	const auto blankModFS = commonItems::ModFilesystem(V3Path, overrideMods);
 
 	Log(LogLevel::Progress) << "45 %";
 	Log(LogLevel::Info) << "* Soaking up the shine *";
@@ -40,6 +43,7 @@ V3::World::World(const Configuration& configuration, const EU4::World& sourceWor
 	politicalManager.loadColonialTagMapperRules("configurables/colonial_tags.txt");
 	cultureMapper.expandCulturalMappings(clayManager, sourceWorld.getCultureLoader(), sourceWorld.getReligionLoader());
 	localizationLoader.scrapeLocalizations(dwFS);
+	vanillaLocalizationLoader.scrapeLocalizations(blankModFS);
 
 	Log(LogLevel::Info) << "*** Hello Vicky 3, creating world. ***";
 	Log(LogLevel::Progress) << "46 %";

--- a/EU4toV3/Source/V3World/V3World.cpp
+++ b/EU4toV3/Source/V3World/V3World.cpp
@@ -37,6 +37,7 @@ V3::World::World(const Configuration& configuration, const EU4::World& sourceWor
 	politicalManager.loadLawDefinitions(dwFS);
 	politicalManager.loadDiplomaticMapperRules("configurables/diplomatic_map.txt");
 	politicalManager.loadCharacterTraitMapperRules("configurables/character_traits.txt");
+	politicalManager.loadColonialTagMapperRules("configurables/colonial_tags.txt");
 	cultureMapper.expandCulturalMappings(clayManager, sourceWorld.getCultureLoader(), sourceWorld.getReligionLoader());
 	localizationLoader.scrapeLocalizations(dwFS);
 
@@ -82,6 +83,8 @@ V3::World::World(const Configuration& configuration, const EU4::World& sourceWor
 		 sourceWorld.getReligionLoader(),
 		 localizationLoader,
 		 sourceWorld.getEU4Localizations());
+
+	politicalManager.attemptColonialTagReplacement(cultureMapper.getColonialRegionMapper(), clayManager);
 
 	popManager.generatePops(clayManager);
 

--- a/EU4toV3/Source/V3World/V3World.h
+++ b/EU4toV3/Source/V3World/V3World.h
@@ -28,6 +28,7 @@ class World
 	[[nodiscard]] const auto& getCultureMapper() const { return cultureMapper; }
 	[[nodiscard]] const auto& getReligionMapper() const { return religionMapper; }
 	[[nodiscard]] const auto& getDatingData() const { return datingData; }
+	[[nodiscard]] const auto& getVanillaLocalizations() const { return vanillaLocalizationLoader; }
 
   private:
 	std::string V3Path;
@@ -38,6 +39,7 @@ class World
 	PoliticalManager politicalManager;
 	PopManager popManager;
 	LocalizationLoader localizationLoader;
+	LocalizationLoader vanillaLocalizationLoader;
 
 	mappers::ProvinceMapper provinceMapper;
 	mappers::ReligionMapper religionMapper;

--- a/EU4toV3Tests/EU4ToV3Tests.vcxproj
+++ b/EU4toV3Tests/EU4ToV3Tests.vcxproj
@@ -138,6 +138,8 @@
     <ClCompile Include="..\EU4toV3\Source\Mappers\CharacterTraitMapper\SkillMapping.cpp" />
     <ClCompile Include="..\EU4toV3\Source\Mappers\ColonialRegionMapper\ColonialRegionMapper.cpp" />
     <ClCompile Include="..\EU4toV3\Source\Mappers\ColonialRegionMapper\ColonialRegionMapping.cpp" />
+    <ClCompile Include="..\EU4toV3\Source\Mappers\ColonialTagMapper\ColonialTagMapper.cpp" />
+    <ClCompile Include="..\EU4toV3\Source\Mappers\ColonialTagMapper\ColonialTagMapping.cpp" />
     <ClCompile Include="..\EU4toV3\Source\Mappers\CountryMapper\CountryMapper.cpp" />
     <ClCompile Include="..\EU4toV3\Source\Mappers\CountryMapper\CountryMapping.cpp" />
     <ClCompile Include="..\EU4toV3\Source\Mappers\CultureMapper\CultureDefinitionLoader\CultureDefinitionEntry.cpp" />
@@ -274,6 +276,8 @@
     <ClCompile Include="MapperTests\CharacterTraitMapperTests\SkillMappingTests.cpp" />
     <ClCompile Include="MapperTests\ColonialRegionMapperTests\ColonialRegionMapperTests.cpp" />
     <ClCompile Include="MapperTests\ColonialRegionMapperTests\ColonialRegionMappingTests.cpp" />
+    <ClCompile Include="MapperTests\ColonialTagMapperTests\ColonialTagMapperTests.cpp" />
+    <ClCompile Include="MapperTests\ColonialTagMapperTests\ColonialTagMappingTests.cpp" />
     <ClCompile Include="MapperTests\CountryMapperTests\CountryMapperTests.cpp" />
     <ClCompile Include="MapperTests\CountryMapperTests\CountryMappingTests.cpp" />
     <ClCompile Include="MapperTests\CultureMapperTests\CultureDefinitionLoaderTests\CultureDefinitionEntryTests.cpp" />
@@ -647,6 +651,11 @@
   <ItemGroup>
     <CopyFileToFolders Include="TestFiles\vic3installation\game\common\flag_definitions\00_flag_definitions.txt">
       <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)/TestFiles/vic3installation/game/common/flag_definitions</DestinationFolders>
+    </CopyFileToFolders>
+  </ItemGroup>
+  <ItemGroup>
+    <CopyFileToFolders Include="TestFiles\configurables\colonial_tags.txt">
+      <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutDir)/TestFiles/configurables</DestinationFolders>
     </CopyFileToFolders>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/EU4toV3Tests/EU4ToV3Tests.vcxproj.filters
+++ b/EU4toV3Tests/EU4ToV3Tests.vcxproj.filters
@@ -841,6 +841,18 @@
     <ClCompile Include="..\commonItems\targa.cpp">
       <Filter>ConverterFiles\commonItems</Filter>
     </ClCompile>
+    <ClCompile Include="..\EU4toV3\Source\Mappers\ColonialTagMapper\ColonialTagMapper.cpp">
+      <Filter>ConverterFiles\Mappers\ColonialTagMapper</Filter>
+    </ClCompile>
+    <ClCompile Include="..\EU4toV3\Source\Mappers\ColonialTagMapper\ColonialTagMapping.cpp">
+      <Filter>ConverterFiles\Mappers\ColonialTagMapper</Filter>
+    </ClCompile>
+    <ClCompile Include="MapperTests\ColonialTagMapperTests\ColonialTagMapperTests.cpp">
+      <Filter>MapperTests\ColonialTagMapperTests</Filter>
+    </ClCompile>
+    <ClCompile Include="MapperTests\ColonialTagMapperTests\ColonialTagMappingTests.cpp">
+      <Filter>MapperTests\ColonialTagMapperTests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="EU4WorldTests">
@@ -1386,6 +1398,12 @@
     <Filter Include="TestFiles\vic3installation\game\common\flag_definitions">
       <UniqueIdentifier>{ca85255b-b270-4a84-9a99-f95e64bdddc0}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ConverterFiles\Mappers\ColonialTagMapper">
+      <UniqueIdentifier>{d211ade1-d83c-4852-a3ef-9af5f9f198fc}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="MapperTests\ColonialTagMapperTests">
+      <UniqueIdentifier>{534a3502-8b86-4538-b3d1-392ee938a0a9}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\commonItems\ConvenientParser.h">
@@ -1578,6 +1596,9 @@
     </CopyFileToFolders>
     <CopyFileToFolders Include="TestFiles\vic3installation\game\common\flag_definitions\00_flag_definitions.txt">
       <Filter>TestFiles\vic3installation\game\common\flag_definitions</Filter>
+    </CopyFileToFolders>
+    <CopyFileToFolders Include="TestFiles\configurables\colonial_tags.txt">
+      <Filter>TestFiles\configurables</Filter>
     </CopyFileToFolders>
   </ItemGroup>
 </Project>

--- a/EU4toV3Tests/MapperTests/ColonialTagMapperTests/ColonialTagMapperTests.cpp
+++ b/EU4toV3Tests/MapperTests/ColonialTagMapperTests/ColonialTagMapperTests.cpp
@@ -1,0 +1,41 @@
+#include "ClayManager/ClayManager.h"
+#include "ClayManager/State/SubState.h"
+#include "ColonialRegionMapper/ColonialRegionMapper.h"
+#include "ColonialTagMapper/ColonialTagMapper.h"
+#include "PoliticalManager/Country/Country.h"
+#include "gtest/gtest.h"
+
+TEST(Mappers_ColonialTagMapperTests, rulesCanBeLoadedAndMatched)
+{
+	mappers::ColonialTagMapper mapper;
+	mapper.loadMappingRules("TestFiles/configurables/colonial_tags.txt");
+
+	const auto country = std::make_shared<V3::Country>();
+	const auto subState = std::make_shared<V3::SubState>();
+	country->addSubState(subState);
+	V3::ProcessedData data;
+	data.capitalStateName = "STATE_BRITISH_COLUMBIA";
+	country->setProcessedData(data);
+
+	const auto& match = mapper.matchColonialTag(*country, {}, {});
+
+	ASSERT_TRUE(match);
+	EXPECT_EQ("COL", *match);
+}
+
+TEST(Mappers_ColonialTagMapperTests, MatchWillFailForNoMatches)
+{
+	mappers::ColonialTagMapper mapper;
+	mapper.loadMappingRules("TestFiles/configurables/colonial_tags.txt");
+
+	const auto country = std::make_shared<V3::Country>();
+	const auto subState = std::make_shared<V3::SubState>();
+	country->addSubState(subState);
+	V3::ProcessedData data;
+	data.capitalStateName = "STATE_WRONG_COLUMBIA";
+	country->setProcessedData(data);
+
+	const auto& match = mapper.matchColonialTag(*country, {}, {});
+
+	EXPECT_FALSE(match);
+}

--- a/EU4toV3Tests/MapperTests/ColonialTagMapperTests/ColonialTagMappingTests.cpp
+++ b/EU4toV3Tests/MapperTests/ColonialTagMapperTests/ColonialTagMappingTests.cpp
@@ -1,0 +1,57 @@
+#include "ClayManager/ClayManager.h"
+#include "ClayManager/State/SubState.h"
+#include "ColonialRegionMapper/ColonialRegionMapper.h"
+#include "ColonialTagMapper/ColonialTagMapping.h"
+#include "PoliticalManager/Country/Country.h"
+#include "gtest/gtest.h"
+#include <gmock/gmock-matchers.h>
+
+TEST(Mappers_ColonialTagMappingTests, MatchFailsForNoSubStates)
+{
+
+	std::stringstream input;
+	input << "region = STATE_BRITISH_COLUMBIA tag = COL";
+	const mappers::ColonialTagMapping mapping(input);
+
+	const auto country = std::make_shared<V3::Country>();
+
+	const auto& match = mapping.matchColonialTag(*country, {}, {});
+
+	EXPECT_FALSE(match);
+}
+
+TEST(Mappers_ColonialTagMappingTests, MatchFailsForNoCapital)
+{
+
+	std::stringstream input;
+	input << "region = STATE_BRITISH_COLUMBIA tag = COL";
+	const mappers::ColonialTagMapping mapping(input);
+
+	const auto country = std::make_shared<V3::Country>();
+	const auto subState = std::make_shared<V3::SubState>();
+	country->addSubState(subState);
+
+	const auto& match = mapping.matchColonialTag(*country, {}, {});
+
+	EXPECT_FALSE(match);
+}
+
+TEST(Mappers_ColonialTagMappingTests, MatchPassesForCorrectCapital)
+{
+
+	std::stringstream input;
+	input << "region = STATE_BRITISH_COLUMBIA tag = COL";
+	const mappers::ColonialTagMapping mapping(input);
+
+	const auto country = std::make_shared<V3::Country>();
+	const auto subState = std::make_shared<V3::SubState>();
+	country->addSubState(subState);
+	V3::ProcessedData data;
+	data.capitalStateName = "STATE_BRITISH_COLUMBIA";
+	country->setProcessedData(data);
+
+	const auto& match = mapping.matchColonialTag(*country, {}, {});
+
+	ASSERT_TRUE(match);
+	EXPECT_EQ("COL", *match);
+}

--- a/EU4toV3Tests/TestFiles/configurables/colonial_tags.txt
+++ b/EU4toV3Tests/TestFiles/configurables/colonial_tags.txt
@@ -1,0 +1,3 @@
+# link = { region = canada_colony alone = CAN } # Testing this is very difficult.
+
+link = { region = STATE_BRITISH_COLUMBIA tag = COL }


### PR DESCRIPTION
- swap useless tags for better colonial tags.
- don't export known locs so we may plug into better-quality vanilla locs.