### PR TITLE
Terrain econ balancing & capacity check

### DIFF
--- a/EU4toV3/Data_Files/configurables/economy/buildings_map.txt
+++ b/EU4toV3/Data_Files/configurables/economy/buildings_map.txt
@@ -15,6 +15,7 @@ link = { eu4 = wharf vic3 = { building_fishing_wharf } }
 link = { eu4 = weapons vic3 = { building_arms_industry } }
 link = { eu4 = tradecompany vic3 = { building_port } }
 link = { eu4 = university vic3 = { building_university } }
+link = { eu4 = grand_shipyard vic3 = { building_shipyards } }
 
 link = { 
     eu4 = textile
@@ -30,6 +31,7 @@ link = {
         building_glassworks
         building_paper_mills
         building_logging_camp
+        building_tooling_workshops
     } 
 }
 

--- a/EU4toV3/Data_Files/configurables/economy/econ_defines.txt
+++ b/EU4toV3/Data_Files/configurables/economy/econ_defines.txt
@@ -3,7 +3,7 @@
 
 # (0 <-> INTMAX)
 # Total # of CP in the globe
-global_construction_points = 1451750
+global_construction_points = 1500000
 vn_global_construction_points = 871050
 
 # (0 <-> 1)

--- a/EU4toV3/Data_Files/configurables/economy/econ_defines.txt
+++ b/EU4toV3/Data_Files/configurables/economy/econ_defines.txt
@@ -20,4 +20,4 @@ state_trait_strength = 0.5
 
 # (-1 <-> 1)
 # The higher this number is, the more a single sector of industry will cluster into fewer states.
-packet_factor = 0
+packet_factor = -0.1

--- a/EU4toV3/Data_Files/configurables/economy/national_budget.txt
+++ b/EU4toV3/Data_Files/configurables/economy/national_budget.txt
@@ -142,6 +142,16 @@ western_industry = {
 
     building_food_industry
     building_arms_industry
+
+    # No effect if no EuroCentrism
+    add= {
+        value = -2
+        industry_score_less_than = 4
+    }
+    add= {
+        value = -3
+        industry_score_less_than = 3
+    }
 }
 
 tooling_industry = {

--- a/EU4toV3/Data_Files/configurables/economy/national_budget.txt
+++ b/EU4toV3/Data_Files/configurables/economy/national_budget.txt
@@ -7,13 +7,13 @@
 # but still must face the realities of technology/resource availability and the desire of the states.
 
 construction = {
-    weight = 0.25
+    weight = 0.15
 
     building_construction_sector
 }
 
 infrastructure = {
-    weight = 5
+    weight = 3
 
     building_port
     building_railway
@@ -106,7 +106,7 @@ plantation = {
 }
 
 whaling = {
-    weight = 0.5
+    weight = 0.4
 
     building_whaling_station
 
@@ -133,7 +133,7 @@ light_industry = {
     # Industry score from configurables/westernization.txt. No effect if no EuroCentrism
     multiply = {
         value = 0
-        industry_score_less_than = 2
+        industry_score_less_than = 1
     }
 }
 
@@ -170,7 +170,7 @@ heavy_industry = {
     building_munition_plants
 
    add = {
-       value = 3
+       value = 4
        is_eu4_gp = yes
    }
 }

--- a/EU4toV3/Data_Files/configurables/economy/national_budget.txt
+++ b/EU4toV3/Data_Files/configurables/economy/national_budget.txt
@@ -66,7 +66,7 @@ extraction = {
 industrial_mining = {
 	industrial = yes
 
-    weight = 8
+    weight = 9
 
     building_iron_mine
     building_coal_mine
@@ -112,23 +112,21 @@ whaling = {
 
 }
 
-scholarly = {
+shipwrights = {
+    weight = 4
+
     industrial = yes
 
-    weight = 2.5
-
-    building_arts_academy
-    building_university
+    building_shipyards
 }
 
 light_industry = {
-    weight = 25
+    weight = 21
 
     building_textile_mills
     building_furniture_manufacturies
     building_glassworks
     building_paper_mills
-    building_shipyards
 
     # Industry score from configurables/westernization.txt. No effect if no EuroCentrism
     multiply = {
@@ -157,6 +155,15 @@ tooling_industry = {
        value = 2.5
        is_eu4_gp = yes
    }
+}
+
+scholarly = {
+    industrial = yes
+
+    weight = 2.5
+
+    building_arts_academy
+    building_university
 }
 
 heavy_industry = {

--- a/EU4toV3/Data_Files/configurables/economy/terrain_econ_modifiers.txt
+++ b/EU4toV3/Data_Files/configurables/economy/terrain_econ_modifiers.txt
@@ -9,21 +9,30 @@
 
 
 coastal = {
-    priority = 0.5
+    priority = 0.4
 
-    building_fishing_wharf = 1.5
-    building_whaling_station = 0.5
-    building_shipyards = 1
+    building_barracks = 0.2
+    building_naval_base = 0.4
+    building_port = 0.6
+
+    building_fishing_wharf = 0.5
+    building_whaling_station = 0.3
+    building_shipyards = 0.5
+    building_tooling_workshops = 0.2
     building_textile_mills = 0.2
     building_furniture_manufactories = 0.2
+    building_university
     building_glassworks = 0.1
     building_paper_mills = 0.1
+    building_logging_camp = 0.1
 }
 
 desert = {
     priority = -0.3
 
-    building_glassworks = 0.2
+    building_glassworks = 0.3
+    building_lead_mine = 0.2
+    building_livestock_ranch = 0.1
 
     building_rye_farm = -0.3
     building_rice_farm = -0.3
@@ -35,45 +44,60 @@ desert = {
 forest = {
     priority = 0.1
 
-    building_paper_mills = 0.2
-    building_shipyards = 0.2
-    building_furniture_manufactories = 0.1
-    building_logging_camp = 0.8
+    building_paper_mills = 0.3
+    building_shipyards = 0.3
+    building_furniture_manufactories = 0.2
+    building_arms_industry = 0.15
+    building_glassworks = 0.1
+    building_tooling_workshops = 0.1
+    building_university = 0.05
+    building_logging_camp = 0.7
 }
 
 hills = {
     priority = 0
 
-    building_iron_mine = 0.4
+    building_iron_mine = 0.6
     building_lead_mine = 0.1
-    building_coal_mine = 0.2
-    building_sulfur_mine = 0.2
-    building_gold_mine = 0.2
-    building_livestock_ranch = 0.6
+    building_coal_mine = 0.5
+    building_gold_mine = 0.5
+    building_arms_industry = 0.2
+    building_steel_mills = 0.3
+    building_motor_industry = 0.3
+    building_arts_academy = 0.1
+    building_tooling_workshops = 0.1
+
+    building_livestock_ranch = 0.3
+    building_opium_plantation = 0.4
 }
 
 jungle = {
     priority = -0.1
 
-    building_logging_camp = 0.2
-    building_coffee_plantation = 0.2
-    building_dye_plantation = 0.2
-    building_opium_plantation = 0.2
-    building_tea_plantation = 0.2
+    building_logging_camp = 0.5
+    building_dye_plantation = 0.3
+    building_sugar_plantation = 0.3
     building_tobacco_plantation = 0.2
-    building_sugar_plantation = 0.2
     building_banana_plantation = 0.2
+    building_coffee_plantation = 0.1
     building_livestock_ranch = 0.1
+    building_silk_plantation = 0.1
+
+    building_motor_industry = -0.5
 }
 
 mountain = {
     priority = -0.2
 
-    building_iron_mine = 0.8
+    building_iron_mine = 0.6
     building_lead_mine = 0.2
-    building_coal_mine = 1
-    building_sulfur_mine = 0.5
+    building_coal_mine = 0.7
     building_gold_mine = 1
+    building_opium_plantation = 0.3
+    building_chemical_plants = 0.1
+    building_munition_plants = 0.05
+    building_arts_academy = 0.3
+    building_tooling_workshops = 0.2
 
     building_rye_farm = -0.5
     building_rice_farm = -0.5
@@ -89,6 +113,22 @@ plains = {
     building_wheat_farm = 0.5
     building_maize_farm = 0.5
     building_millet_farm = 0.5
+    building_rice_farm = 0.5
+    building_dye_plantation = 0.4
+    building_cotton_plantation = 0.3
+    building_silk_plantation = 0.3
+    building_tea_plantation = 0.3
+    building_furniture_manufactories = 0.2
+    building_university = 0.2
+    building_barracks = 0.2
+    building_railway = 0.1
+    building_food_industry = 0.1
+    building_textile_mills = 0.1
+    building_paper_mills = 0.1
+    building_chemical_plants = 0.05
+    building_steel_mills = 0.05
+    building_motor_industry = 0.05
+    building_munition_plants = 0.05
 }
 
 savanna = {
@@ -97,31 +137,62 @@ savanna = {
     building_wheat_farm = 0.3
     building_maize_farm = 0.3
     building_millet_farm = 0.4
+    building_lead_mine = 0.1
+    building_coal_mine = 0.1
+    building_munition_plants = 0.05
+
+    building_motor_industry = -0.5
 }
 
 snow = {
-    priority = -0.3
+    priority = -0.4
 
-    building_rye_farm = -0.3
-    building_rice_farm = -0.3
-    building_wheat_farm = -0.3
-    building_maize_farm = -0.3
-    building_millet_farm = -0.3
+    building_whaling_station = 1
+
+    building_rye_farm = -0.7
+    building_rice_farm = -0.7
+    building_wheat_farm = -0.7
+    building_maize_farm = -0.7
+    building_millet_farm = -0.7
+    building_motor_industry = -0.5
+    building_steel_mills = -0.5
+    building_chemical_plants = -0.5
+    building_munition_plants = -0.5
+    building_railway = -0.5
+    building_university = -0.4
 }
 
 tundra = {
-    priority = -0.4
+    priority = -0.3
+
+    building_whaling_station = 0.1
+    building_livestock_ranch = 0.1
+    building_textile_mills = 0.05
 
     building_rye_farm = -0.5
     building_rice_farm = -0.5
     building_wheat_farm = -0.5
     building_maize_farm = -0.5
     building_millet_farm = -0.5
+    building_motor_industry = -0.3
+    building_steel_mills = -0.3
+    building_chemical_plants = -0.3
+    building_munition_plants = -0.3
+    building_railway = -0.3
+    building_university = -0.2
 }
 
 wetland = {
     priority = 0
 
-    building_rice_farm = 0.6
+    building_fishing_wharf = 0.5
     building_sulfur_mine = 0.2
+    building_paper_mills = 0.1
+    building_port = 0.1
+    building_logging_camp = 0.1
+    building_chemical_plants = 0.1
+    building_munition_plants = 0.05
+    building_dye_plantation = 0.1
+    building_silk_plantation = 0.1
+    building_cotton_plantation = 0.1
 }

--- a/EU4toV3/Data_Files/configurables/economy/terrain_econ_modifiers.txt
+++ b/EU4toV3/Data_Files/configurables/economy/terrain_econ_modifiers.txt
@@ -150,6 +150,7 @@ snow = {
     priority = -0.4
 
     building_whaling_station = 1
+    building_arts_academy = 0.1
 
     building_rye_farm = -0.7
     building_rice_farm = -0.7
@@ -171,6 +172,7 @@ tundra = {
     building_livestock_ranch = 0.1
     building_fishing_wharf = 0.1
     building_textile_mills = 0.05
+    building_arts_academy = 0.05
 
     building_rye_farm = -0.5
     building_rice_farm = -0.5

--- a/EU4toV3/Data_Files/configurables/economy/terrain_econ_modifiers.txt
+++ b/EU4toV3/Data_Files/configurables/economy/terrain_econ_modifiers.txt
@@ -3,9 +3,10 @@
 # All values are 0 by default if not listed
 #
 # priority = x; A % bonus to a country's willingness to invest in a state
-# building_name = x; A % bonus to the chance of a building being built in a state
+# building_name = x; An additive bonus to the weight a state scores a building with
 #
-# 0.2 = 20% bonus.
+# priority = 0.2 = 20% priority bonus.
+# building = 0.2 = +0.2 weight bonus.
 
 
 coastal = {
@@ -15,13 +16,13 @@ coastal = {
     building_naval_base = 0.4
     building_port = 0.6
 
-    building_fishing_wharf = 0.5
+    building_fishing_wharf = 0.3
     building_whaling_station = 0.3
-    building_shipyards = 0.5
+    building_shipyards = 0.2
     building_tooling_workshops = 0.2
     building_textile_mills = 0.2
     building_furniture_manufactories = 0.2
-    building_university
+    building_university = 0.2
     building_glassworks = 0.1
     building_paper_mills = 0.1
     building_logging_camp = 0.1
@@ -45,13 +46,14 @@ forest = {
     priority = 0.1
 
     building_paper_mills = 0.3
-    building_shipyards = 0.3
     building_furniture_manufactories = 0.2
     building_arms_industry = 0.15
+    building_shipyards = 0.1
     building_glassworks = 0.1
     building_tooling_workshops = 0.1
     building_university = 0.05
     building_logging_camp = 0.7
+    building_fishing_wharf = 0.1
 }
 
 hills = {
@@ -119,16 +121,16 @@ plains = {
     building_silk_plantation = 0.3
     building_tea_plantation = 0.3
     building_furniture_manufactories = 0.2
-    building_university = 0.2
     building_barracks = 0.2
     building_railway = 0.1
     building_food_industry = 0.1
     building_textile_mills = 0.1
-    building_paper_mills = 0.1
+    building_glassworks = 0.08
     building_chemical_plants = 0.05
     building_steel_mills = 0.05
     building_motor_industry = 0.05
     building_munition_plants = 0.05
+    building_paper_mills = 0.02
 }
 
 savanna = {
@@ -165,8 +167,9 @@ snow = {
 tundra = {
     priority = -0.3
 
-    building_whaling_station = 0.1
+    building_whaling_station = 0.2
     building_livestock_ranch = 0.1
+    building_fishing_wharf = 0.1
     building_textile_mills = 0.05
 
     building_rye_farm = -0.5

--- a/EU4toV3/Source/V3World/ClayManager/State/SubState.cpp
+++ b/EU4toV3/Source/V3World/ClayManager/State/SubState.cpp
@@ -46,6 +46,15 @@ void V3::SubState::setProvinces(const ProvinceMap& theProvinces)
 	calculateTerrainFrequency();
 }
 
+int V3::SubState::getResource(const std::string& theResource) const
+{
+	if (const auto resource = resources.find(theResource); resource != resources.end())
+	{
+		return resource->second;
+	}
+	return 0;
+}
+
 double V3::SubState::getTerrainFrequency(const std::string& theTerrain) const
 {
 	if (const auto terrain = terrainFrequency.find(theTerrain); terrain != terrainFrequency.end())

--- a/EU4toV3/Source/V3World/ClayManager/State/SubState.h
+++ b/EU4toV3/Source/V3World/ClayManager/State/SubState.h
@@ -111,7 +111,7 @@ class SubState
 
 	[[nodiscard]] const auto& getLandshare() const { return landshare; }
 	[[nodiscard]] const auto& getInfrastructure() const { return infrastructure; }
-	[[nodiscard]] const auto& getResource(const std::string& theResource) { return resources[theResource]; }
+	[[nodiscard]] int getResource(const std::string& theResource) const;
 	[[nodiscard]] double getTerrainFrequency(const std::string& theTerrain) const;
 	[[nodiscard]] const auto& getTerrainFrequencies() { return terrainFrequency; }
 	[[nodiscard]] const auto& getDemographics() const { return demographics; }

--- a/EU4toV3/Source/V3World/EconomyManager/EconomyManager.cpp
+++ b/EU4toV3/Source/V3World/EconomyManager/EconomyManager.cpp
@@ -585,7 +585,7 @@ void V3::EconomyManager::buildBuilding(const std::shared_ptr<Building>& building
 
 	// If arable, decrease arable land. This does have a side effect of no arable building being able to use more than 50% of the arable land
 	const auto& arables = subState->getHomeState()->getArableResources();
-	if (const auto& hasArable = std::ranges::find(arables,""); hasArable != arables.end())
+	if (const auto& hasArable = std::ranges::find(arables, ""); hasArable != arables.end())
 	{
 		subState->setResource("bg_agriculture", subState->getResource("bg_agriculture") - p);
 	}

--- a/EU4toV3/Source/V3World/EconomyManager/EconomyManager.cpp
+++ b/EU4toV3/Source/V3World/EconomyManager/EconomyManager.cpp
@@ -582,6 +582,13 @@ void V3::EconomyManager::buildBuilding(const std::shared_ptr<Building>& building
 	subState->spendCPBudget(building->getConstructionCost() * p);
 	sector->spendCP(building->getConstructionCost() * p);
 	building->setLevel(building->getLevel() + p);
+
+	// If arable, decrease arable land. This does have a side effect of no arable building being able to use more than 50% of the arable land
+	const auto& arables = subState->getHomeState()->getArableResources();
+	if (const auto& hasArable = std::ranges::find(arables,""); hasArable != arables.end())
+	{
+		subState->setResource("arable", subState->getResource("arable") - p);
+	}
 }
 
 void V3::EconomyManager::removeSubStateIfFinished(std::vector<std::shared_ptr<SubState>>& subStates,
@@ -608,7 +615,7 @@ int V3::EconomyManager::determinePacketSize(const std::shared_ptr<Building>& bui
 	// Packet size is the minimum  of (Sector CP budget/cost, SubState CP budget/cost, SubState capacity, and our clustering metric)
 	const int sectorPacket = sector->getCPBudget() / building->getConstructionCost();
 	const int subStatePacket = subState->getCPBudget() / building->getConstructionCost();
-	const int capacityPacket = subState->getBuildingCapacity(*building, buildingGroups, lawsMap, techMap.getTechs(), stateTraits);
+	const int capacityPacket = subState->getBuildingCapacity(*building, buildingGroups, lawsMap, techMap.getTechs(), stateTraits) - building->getLevel();
 	const int clusterPacket = getClusterPacket(building->getConstructionCost(), subStates);
 
 	const int packet = std::max(std::min({sectorPacket, subStatePacket, capacityPacket, clusterPacket}), 1);

--- a/EU4toV3/Source/V3World/EconomyManager/EconomyManager.cpp
+++ b/EU4toV3/Source/V3World/EconomyManager/EconomyManager.cpp
@@ -585,7 +585,7 @@ void V3::EconomyManager::buildBuilding(const std::shared_ptr<Building>& building
 
 	// If arable, decrease arable land. This does have a side effect of no arable building being able to use more than 50% of the arable land
 	const auto& arables = subState->getHomeState()->getArableResources();
-	if (const auto& hasArable = std::ranges::find(arables, ""); hasArable != arables.end())
+	if (const auto& isArable = std::ranges::find(arables, building->getBuildingGroup()); isArable != arables.end())
 	{
 		subState->setResource("bg_agriculture", subState->getResource("bg_agriculture") - p);
 	}

--- a/EU4toV3/Source/V3World/EconomyManager/EconomyManager.cpp
+++ b/EU4toV3/Source/V3World/EconomyManager/EconomyManager.cpp
@@ -587,7 +587,7 @@ void V3::EconomyManager::buildBuilding(const std::shared_ptr<Building>& building
 	const auto& arables = subState->getHomeState()->getArableResources();
 	if (const auto& hasArable = std::ranges::find(arables,""); hasArable != arables.end())
 	{
-		subState->setResource("arable", subState->getResource("arable") - p);
+		subState->setResource("bg_agriculture", subState->getResource("bg_agriculture") - p);
 	}
 }
 


### PR DESCRIPTION
German minors in the alps get to choose 1 building. They choose arts academy. All is well.
On a serious note, shipyards, light industry and the uni/arts academy balance should be pretty good now. Global CP increase since we're building some ports. I'm very happy with how things look in my test save, so I know you can at least overfit the econ configurables to one exact save and get a very good result within an hour of fiddling.