### PR TITLE
Multiple corrections

### DIFF
--- a/.github/workflows/linux_codeql-analysis.yml
+++ b/.github/workflows/linux_codeql-analysis.yml
@@ -7,9 +7,9 @@ on:
   schedule:
     - cron: '0 16 * * 6'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.ref }}
+#  cancel-in-progress: true
 
 jobs:
   analyze_main:

--- a/.github/workflows/windows_build_test_and_push.yml
+++ b/.github/workflows/windows_build_test_and_push.yml
@@ -5,9 +5,9 @@ on:
   pull_request:
     branches: [ master ]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+#concurrency:
+#  group: ${{ github.workflow }}-${{ github.ref }}
+#  cancel-in-progress: true
 
 jobs:
   build_test_and_publish:

--- a/EU4ToVic3/Source/Mappers/ColonialTagMapper/ColonialTagMapper.h
+++ b/EU4ToVic3/Source/Mappers/ColonialTagMapper/ColonialTagMapper.h
@@ -23,6 +23,7 @@ class ColonialTagMapper: commonItems::parser
 	void registerKeys();
 
 	std::vector<ColonialTagMapping> colonialTagMappings;
+	std::set<std::string> knownColonialTags;
 };
 } // namespace mappers
 

--- a/EU4ToVic3/Source/Mappers/ColonialTagMapper/ColonialTagMapping.h
+++ b/EU4ToVic3/Source/Mappers/ColonialTagMapper/ColonialTagMapping.h
@@ -19,6 +19,7 @@ class ColonialTagMapping: commonItems::parser
 	[[nodiscard]] std::optional<std::string> matchColonialTag(const V3::Country& country,
 		 const ColonialRegionMapper& colonialRegionMapper,
 		 const V3::ClayManager& clayManager) const;
+	[[nodiscard]] const auto& getTag() const { return tag; }
 
   private:
 	void registerKeys();

--- a/EU4ToVic3/Source/Mappers/CountryMapper/CountryMapper.cpp
+++ b/EU4ToVic3/Source/Mappers/CountryMapper/CountryMapper.cpp
@@ -30,18 +30,24 @@ void mappers::CountryMapper::registerKeys()
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
 }
 
-bool mappers::CountryMapper::tagIsDynamic(const std::string& tag)
+bool mappers::CountryMapper::tagIsDynamic(const std::string& tag) const
 {
 	if (tag.size() < 3) // A shorter tag is certainly dynamic. Also probably illegal but that isn't our problem.
+		return true;
+
+	if (dynamicallyGeneratedTags.contains(tag))
 		return true;
 
 	// Generally a strong check for colonial tags, eg. C04. Can be used for other purposes.
 	return isalpha(tag[0]) && isdigit(tag[1]) && isdigit(tag[2]);
 }
 
-bool mappers::CountryMapper::tagIsNonCanon(const std::string& tag)
+bool mappers::CountryMapper::tagIsNonCanon(const std::string& tag) const
 {
 	if (tag.size() < 3) // A shorter tag is certainly non-canon. Also probably illegal but that isn't our problem.
+		return true;
+
+	if (dynamicallyGeneratedTags.contains(tag))
 		return true;
 
 	// A truism for non-canon countries, generally both dynamic C04, and converter-generated (by CK3toEU4), eg. Z0A, Y0B..
@@ -64,6 +70,7 @@ std::string mappers::CountryMapper::generateNewTag()
 			--generatedV3TagPrefix;
 		}
 	} while (tagIsAlreadyAssigned(v3Tag) || knownVanillaV3Tags.contains(v3Tag));
+	dynamicallyGeneratedTags.emplace(v3Tag);
 	return v3Tag;
 }
 

--- a/EU4ToVic3/Source/Mappers/CountryMapper/CountryMapper.h
+++ b/EU4ToVic3/Source/Mappers/CountryMapper/CountryMapper.h
@@ -22,8 +22,8 @@ class CountryMapper: commonItems::parser
 	[[nodiscard]] std::optional<std::string> getV3Tag(const std::string& eu4Tag) const;
 	[[nodiscard]] std::optional<std::string> getEU4Tag(const std::string& v3Tag) const;
 	[[nodiscard]] std::optional<std::string> getFlagCode(const std::string& v3Tag) const;
-	[[nodiscard]] static bool tagIsDynamic(const std::string& tag);  // alpha-digit-digit, eg. C01, T15
-	[[nodiscard]] static bool tagIsNonCanon(const std::string& tag); // both dynamic and imported, eg. Z0A, X0J
+	[[nodiscard]] bool tagIsDynamic(const std::string& tag) const;	 // alpha-digit-digit, eg. C01, T15
+	[[nodiscard]] bool tagIsNonCanon(const std::string& tag) const; // both dynamic and imported, eg. Z0A, X0J
 
 	[[nodiscard]] std::string assignV3TagToEU4Country(const std::shared_ptr<EU4::Country>& country);
 	[[nodiscard]] std::string requestNewV3Tag();
@@ -48,6 +48,7 @@ class CountryMapper: commonItems::parser
 	std::map<std::string, std::string> v3FlagCodes; // v3 tag -> flagcode
 	std::set<std::string> unmappedV3Tags;				// stuff we generate on the fly for decentralized countries.
 	std::set<std::string> knownVanillaV3Tags;			// countries we import at game start. Includes names with potential for generated-collisions.
+	std::set<std::string> dynamicallyGeneratedTags; // stuff we created ourselves. Safe to delete if needed.
 
 	char generatedV3TagPrefix = 'X';
 	int generatedV3TagSuffix = 0;

--- a/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDef.h
+++ b/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDef.h
@@ -19,7 +19,8 @@ struct CultureDef
 	std::set<std::string> regalLastNames;
 	std::set<std::string> ethnicities;
 	std::string graphics;
-	bool skipExport = false; // We're skipping *separate* export for defs that we either import or just copy over from blankmod.
+	bool skipProcessing = false; // We're skipping *separate* processing for defs that we import (from DW for example).
+	bool skipExport = false;	  // We're skipping *separate* export for defs that we copy over from blankmod.
 
 	std::map<std::string, std::string> locBlock;
 	std::map<std::string, std::string> nameLocBlock; // all english since we load from disk

--- a/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionEntry.cpp
+++ b/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionEntry.cpp
@@ -15,8 +15,9 @@ std::string normalizeString(const std::string& input)
 }
 } // namespace
 
-mappers::CultureDefinitionEntry::CultureDefinitionEntry(std::istream& theStream, bool skipExport)
+mappers::CultureDefinitionEntry::CultureDefinitionEntry(std::istream& theStream, bool skipProcessing, bool skipExport)
 {
+	cultureDef.skipProcessing = skipProcessing;
 	cultureDef.skipExport = skipExport;
 	registerkeys();
 	parseStream(theStream);
@@ -43,7 +44,7 @@ void mappers::CultureDefinitionEntry::registerkeys()
 	registerKeyword("male_common_first_names", [this](std::istream& theStream) {
 		for (const auto& name: commonItems::getStrings(theStream))
 		{
-			if (cultureDef.skipExport)
+			if (cultureDef.skipProcessing)
 				cultureDef.maleCommonFirstNames.emplace(name);
 			else
 			{
@@ -56,7 +57,7 @@ void mappers::CultureDefinitionEntry::registerkeys()
 	registerKeyword("female_common_first_names", [this](std::istream& theStream) {
 		for (const auto& name: commonItems::getStrings(theStream))
 		{
-			if (cultureDef.skipExport)
+			if (cultureDef.skipProcessing)
 				cultureDef.femaleCommonFirstNames.emplace(name);
 			else
 			{
@@ -69,7 +70,7 @@ void mappers::CultureDefinitionEntry::registerkeys()
 	registerKeyword("noble_last_names", [this](std::istream& theStream) {
 		for (const auto& name: commonItems::getStrings(theStream))
 		{
-			if (cultureDef.skipExport)
+			if (cultureDef.skipProcessing)
 				cultureDef.nobleLastNames.emplace(name);
 			else
 			{
@@ -82,7 +83,7 @@ void mappers::CultureDefinitionEntry::registerkeys()
 	registerKeyword("common_last_names", [this](std::istream& theStream) {
 		for (const auto& name: commonItems::getStrings(theStream))
 		{
-			if (cultureDef.skipExport)
+			if (cultureDef.skipProcessing)
 				cultureDef.commonLastNames.emplace(name);
 			else
 			{
@@ -95,7 +96,7 @@ void mappers::CultureDefinitionEntry::registerkeys()
 	registerKeyword("male_regal_first_names", [this](std::istream& theStream) {
 		for (const auto& name: commonItems::getStrings(theStream))
 		{
-			if (cultureDef.skipExport)
+			if (cultureDef.skipProcessing)
 				cultureDef.maleRegalFirstNames.emplace(name);
 			else
 			{
@@ -108,7 +109,7 @@ void mappers::CultureDefinitionEntry::registerkeys()
 	registerKeyword("female_regal_first_names", [this](std::istream& theStream) {
 		for (const auto& name: commonItems::getStrings(theStream))
 		{
-			if (cultureDef.skipExport)
+			if (cultureDef.skipProcessing)
 				cultureDef.femaleRegalFirstNames.emplace(name);
 			else
 			{
@@ -121,7 +122,7 @@ void mappers::CultureDefinitionEntry::registerkeys()
 	registerKeyword("regal_last_names", [this](std::istream& theStream) {
 		for (const auto& name: commonItems::getStrings(theStream))
 		{
-			if (cultureDef.skipExport)
+			if (cultureDef.skipProcessing)
 				cultureDef.regalLastNames.emplace(name);
 			else
 			{

--- a/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionEntry.h
+++ b/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionEntry.h
@@ -8,7 +8,7 @@ namespace mappers
 class CultureDefinitionEntry: commonItems::parser
 {
   public:
-	explicit CultureDefinitionEntry(std::istream& theStream, bool skipExport);
+	explicit CultureDefinitionEntry(std::istream& theStream, bool skipProcessing, bool skipExport);
 
 	[[nodiscard]] const auto& getCultureDef() const { return cultureDef; }
 

--- a/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.cpp
+++ b/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.cpp
@@ -11,12 +11,20 @@ void mappers::CultureDefinitionLoader::loadDefinitions(const commonItems::ModFil
 	registerKeys();
 	for (const auto& fileName: modFS.GetAllFilesInFolder("/common/cultures/"))
 	{
+		if (getExtension(fileName) != "txt")
+			continue;
+
 		if (fileName.find("99_") != std::string::npos)
-			skipExport = false;
+			skipProcessing = false;
 		else
+			skipProcessing = true;
+
+		if (fileName.find("blankMod") != std::string::npos)
 			skipExport = true;
-		if (getExtension(fileName) == "txt")
-			parseFile(fileName);
+		else
+			skipExport = false;
+
+		parseFile(fileName);
 	}
 	clearRegisteredKeywords();
 	Log(LogLevel::Info) << "<> " << cultureDefinitions.size() << " definitions loaded.";
@@ -32,7 +40,7 @@ void mappers::CultureDefinitionLoader::loadDefinitions(std::istream& theStream)
 void mappers::CultureDefinitionLoader::registerKeys()
 {
 	registerRegex(commonItems::catchallRegex, [this](const std::string& cultureName, std::istream& theStream) {
-		auto relDef = CultureDefinitionEntry(theStream, skipExport).getCultureDef();
+		auto relDef = CultureDefinitionEntry(theStream, skipProcessing, skipExport).getCultureDef();
 		relDef.name = cultureName;
 		cultureDefinitions.emplace(cultureName, relDef);
 	});

--- a/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.h
+++ b/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.h
@@ -19,7 +19,8 @@ class CultureDefinitionLoader: commonItems::parser
 	void registerKeys();
 
 	std::map<std::string, CultureDef> cultureDefinitions;
-	bool skipExport = true; // skip export for cultures not loaded from 99_<...>.txt!
+	bool skipProcessing = true; // skip processing for cultures not loaded from 99_<...>.txt!
+	bool skipExport = true;		 // skip export for cultures loaded from */blankMod/*
 };
 } // namespace mappers
 

--- a/EU4ToVic3/Source/Mappers/CultureMapper/CultureMapper.cpp
+++ b/EU4ToVic3/Source/Mappers/CultureMapper/CultureMapper.cpp
@@ -523,7 +523,8 @@ mappers::CultureDef mappers::CultureMapper::generateCultureDefinition(const V3::
 		}
 		if (const auto& nameListMatch = nameListMapper.getNamesForCulture(sourceCultureName, groupName); !nameListMatch)
 		{
-			Log(LogLevel::Warning) << "EU4 culture " << sourceCultureName << "/" << groupName << " has no mapped namelist! Falling back to EU4 names.";
+			// Can be common. Be silent about this.
+			Log(LogLevel::Debug) << "EU4 culture " << sourceCultureName << "/" << groupName << " has no mapped namelist! Falling back to EU4 names.";
 			copyEU4Names(newDef, sourceCulture); // ok, use eu4 names.
 		}
 		else if (const auto& nameList = nameListLoader.getNameList(nameListMatch->getNamePool()); !nameList)

--- a/EU4ToVic3/Source/Output/outMetadataFile/outMetadataFile.cpp
+++ b/EU4ToVic3/Source/Output/outMetadataFile/outMetadataFile.cpp
@@ -16,7 +16,10 @@ void outMetadataFile(std::ostream& output, const std::string& outName)
 	output << "\t\"tags\" : [\"Alternative History\", \"Conversion\"],\n";
 	output << "\t\"relationships\" : [],\n";
 	output << "\t\"game_custom_data\" : {\n";
-	output << "\t\t\"multiplayer_synchronized\" : true\n";
+	output << "\t\t\"multiplayer_synchronized\" : true,\n";
+	output << "\t\t\"replace_paths\" : [\n";
+	output << "\t\t\t\"common/cultures\"\n";
+	output << "\t\t]\n";
 	output << "\t}\n";
 	output << "}\n";
 }

--- a/EU4ToVic3/Source/V3World/PoliticalManager/PoliticalManager.cpp
+++ b/EU4ToVic3/Source/V3World/PoliticalManager/PoliticalManager.cpp
@@ -655,9 +655,9 @@ void V3::PoliticalManager::attemptColonialTagReplacement(const mappers::Colonial
 		if (!country->getSourceCountry()->isColony())
 			continue;
 
-		// focus only on CXX countries.
+		// focus only on CXX countries. On vic3 side as well! We don't want to delete canonical vic3 countries!
 		const auto& eu4tag = country->getSourceCountry()->getTag();
-		if (!eu4tag.starts_with("C") || !mappers::CountryMapper::tagIsDynamic(eu4tag))
+		if (!eu4tag.starts_with("C") || !countryMapper->tagIsDynamic(eu4tag) || !countryMapper->tagIsDynamic(tag))
 			continue;
 
 		if (const auto replacement = colonialTagMapper.matchColonialTag(*country, colonialRegionMapper, clayManager); replacement)

--- a/EU4ToVic3Tests/MapperTests/ColonialTagMapperTests/ColonialTagMapperTests.cpp
+++ b/EU4ToVic3Tests/MapperTests/ColonialTagMapperTests/ColonialTagMapperTests.cpp
@@ -23,6 +23,24 @@ TEST(Mappers_ColonialTagMapperTests, rulesCanBeLoadedAndMatched)
 	EXPECT_EQ("COL", *match);
 }
 
+TEST(Mappers_ColonialTagMapperTests, MatchWillFailForExistingColonialTag)
+{
+	mappers::ColonialTagMapper mapper;
+	mapper.loadMappingRules("TestFiles/configurables/colonial_tags.txt");
+
+	const auto country = std::make_shared<V3::Country>();
+	country->setTag("COL");
+	const auto subState = std::make_shared<V3::SubState>();
+	country->addSubState(subState);
+	V3::ProcessedData data;
+	data.capitalStateName = "STATE_BRITISH_COLUMBIA";
+	country->setProcessedData(data);
+
+	const auto& match = mapper.matchColonialTag(*country, {}, {});
+
+	EXPECT_FALSE(match);
+}
+
 TEST(Mappers_ColonialTagMapperTests, MatchWillFailForNoMatches)
 {
 	mappers::ColonialTagMapper mapper;

--- a/EU4ToVic3Tests/MapperTests/CountryMapperTests/CountryMapperTests.cpp
+++ b/EU4ToVic3Tests/MapperTests/CountryMapperTests/CountryMapperTests.cpp
@@ -233,23 +233,25 @@ TEST(Mappers_CountryMapperTests, CountryWontGetReservedTag)
 
 TEST(Mappers_CountryMapperTests, tagIsDynamicWorksAsAdvertised)
 {
-	EXPECT_TRUE(mappers::CountryMapper::tagIsDynamic("C01"));
-	EXPECT_FALSE(mappers::CountryMapper::tagIsDynamic("CC1"));
-	EXPECT_FALSE(mappers::CountryMapper::tagIsDynamic("CCC"));
-	EXPECT_FALSE(mappers::CountryMapper::tagIsDynamic("0C0"));
-	EXPECT_FALSE(mappers::CountryMapper::tagIsDynamic("0CC"));
-	EXPECT_FALSE(mappers::CountryMapper::tagIsDynamic("00C"));
+	const mappers::CountryMapper mapper;
+	EXPECT_TRUE(mapper.tagIsDynamic("C01"));
+	EXPECT_FALSE(mapper.tagIsDynamic("CC1"));
+	EXPECT_FALSE(mapper.tagIsDynamic("CCC"));
+	EXPECT_FALSE(mapper.tagIsDynamic("0C0"));
+	EXPECT_FALSE(mapper.tagIsDynamic("0CC"));
+	EXPECT_FALSE(mapper.tagIsDynamic("00C"));
 }
 
 TEST(Mappers_CountryMapperTests, tagIsNonCanonWorksAsAdvertised)
 {
-	EXPECT_TRUE(mappers::CountryMapper::tagIsNonCanon("C01"));
-	EXPECT_TRUE(mappers::CountryMapper::tagIsNonCanon("C0C"));
-	EXPECT_FALSE(mappers::CountryMapper::tagIsNonCanon("CC1"));
-	EXPECT_FALSE(mappers::CountryMapper::tagIsNonCanon("CCC"));
-	EXPECT_FALSE(mappers::CountryMapper::tagIsNonCanon("0C0"));
-	EXPECT_FALSE(mappers::CountryMapper::tagIsNonCanon("0CC"));
-	EXPECT_FALSE(mappers::CountryMapper::tagIsNonCanon("00C"));
+	const mappers::CountryMapper mapper;
+	EXPECT_TRUE(mapper.tagIsNonCanon("C01"));
+	EXPECT_TRUE(mapper.tagIsNonCanon("C0C"));
+	EXPECT_FALSE(mapper.tagIsNonCanon("CC1"));
+	EXPECT_FALSE(mapper.tagIsNonCanon("CCC"));
+	EXPECT_FALSE(mapper.tagIsNonCanon("0C0"));
+	EXPECT_FALSE(mapper.tagIsNonCanon("0CC"));
+	EXPECT_FALSE(mapper.tagIsNonCanon("00C"));
 }
 
 TEST(Mappers_CountryMapperTests, newTagCanBeRequested)

--- a/EU4ToVic3Tests/MapperTests/CultureMapperTests/CultureDefinitionLoaderTests/CultureDefinitionEntryTests.cpp
+++ b/EU4ToVic3Tests/MapperTests/CultureMapperTests/CultureDefinitionLoaderTests/CultureDefinitionEntryTests.cpp
@@ -5,7 +5,7 @@
 TEST(Mappers_CultureDefinitionEntryTests, DefaultsDefaultToDefaults)
 {
 	std::stringstream input;
-	const mappers::CultureDefinitionEntry entry(input, false);
+	const mappers::CultureDefinitionEntry entry(input, false, false);
 
 	EXPECT_TRUE(entry.getCultureDef().name.empty());
 	EXPECT_FALSE(entry.getCultureDef().color);
@@ -20,6 +20,7 @@ TEST(Mappers_CultureDefinitionEntryTests, DefaultsDefaultToDefaults)
 	EXPECT_TRUE(entry.getCultureDef().regalLastNames.empty());
 	EXPECT_TRUE(entry.getCultureDef().ethnicities.empty());
 	EXPECT_TRUE(entry.getCultureDef().graphics.empty());
+	EXPECT_FALSE(entry.getCultureDef().skipProcessing);
 	EXPECT_FALSE(entry.getCultureDef().skipExport);
 }
 
@@ -40,7 +41,7 @@ TEST(Mappers_CultureDefinitionEntryTests, EntryCanBeLoaded)
 	input << "	1 = ethnotest\n";
 	input << "}\n";
 	input << "graphics = graphtest\n";
-	const mappers::CultureDefinitionEntry entry(input, true);
+	const mappers::CultureDefinitionEntry entry(input, true, true);
 
 	EXPECT_TRUE(entry.getCultureDef().name.empty());
 	EXPECT_EQ(commonItems::Color(std::array{1, 2, 3}), *entry.getCultureDef().color);
@@ -54,5 +55,6 @@ TEST(Mappers_CultureDefinitionEntryTests, EntryCanBeLoaded)
 	EXPECT_THAT(entry.getCultureDef().regalLastNames, testing::UnorderedElementsAre("rln1", "rln2"));
 	EXPECT_THAT(entry.getCultureDef().ethnicities, testing::UnorderedElementsAre("ethnotest"));
 	EXPECT_EQ("graphtest", entry.getCultureDef().graphics);
+	EXPECT_TRUE(entry.getCultureDef().skipProcessing);
 	EXPECT_TRUE(entry.getCultureDef().skipExport);
 }


### PR DESCRIPTION
- disable workflow concurrences
- Don't attempt colonial tag replacement for colonial V3 tags
- Don't attempt colonial tag replacement for any canonical or probably-canonical V3 tag
- Export all cultures, including vanilla ones, since religion might have changed. Keep skipping blankMod cultures.