### PR TITLE
HAI is Hainaut in EU4; HAT is Haiti.

### DIFF
--- a/EU4ToVic3/Data_Files/configurables/country_mappings.txt
+++ b/EU4ToVic3/Data_Files/configurables/country_mappings.txt
@@ -240,7 +240,7 @@ link = { name = "Santo Domingo" vic3 = DOM } # Santo Domingo
 link = { name = "El Salvador" vic3 = ELS } # El Salvador
 link = { name = "Guatemala" vic3 = GUA } # Guatemala
 link = { name = "Los Altos" vic3 = ALT } # Los Altos
-link = { eu4 = HAI vic3 = HAI } # Haiti
+link = { eu4 = HAT vic3 = HAI } # Haiti
 link = { eu4 = MEX vic3 = MEX } # Mexico
 link = { name = "Métis Confederacy" vic3 = MTC } # Métis
 link = { name = "Honduras" vic3 = HON } # Honduras


### PR DESCRIPTION
A one character fix that would have prevented Haiti from being in Belgium in my Megacampaign.