### PR TITLE
Liberate slaves in countries where slavery is banned.

### DIFF
--- a/EU4ToVic3/Source/V3World/PoliticalManager/Country/Country.h
+++ b/EU4ToVic3/Source/V3World/PoliticalManager/Country/Country.h
@@ -183,6 +183,7 @@ class Country: commonItems::parser
 	void setTechs(const mappers::TechSetupMapper& techSetupMapper, double productionScore, double militaryScore, double societyScore);
 	void addTech(const std::string& tech) { processedData.techs.emplace(tech); }
 	void addLaw(const auto& lawName) { processedData.laws.emplace(lawName); }
+	bool hasLaw(const auto& lawName) const { return processedData.laws.contains(lawName); };
 	void addInstitution(const auto& institutionName, const int level = 1) { processedData.institutions.emplace(institutionName, level); }
 	[[nodiscard]] Relation& getRelation(const std::string& target);
 	[[nodiscard]] const auto& getRelations() const { return processedData.relations; }

--- a/EU4ToVic3/Source/V3World/PopManager/PopManager.h
+++ b/EU4ToVic3/Source/V3World/PopManager/PopManager.h
@@ -44,6 +44,7 @@ class PopManager
 	void loadSlaveCultureRules(const std::string& filePath);
 	void injectReligionsIntoVanillaPops(const std::map<std::string, mappers::CultureDef>& cultureDefs);
 	void injectReligionsIntoDWPops(const std::map<std::string, mappers::CultureDef>& cultureDefs);
+	void liberateSlaves(const PoliticalManager& politicalManager) const;
 	void alterSlaveCultures(const PoliticalManager& politicalManager,
 		 const ClayManager& clayManager,
 		 const std::map<std::string, mappers::CultureDef>& cultureDefs) const;

--- a/EU4ToVic3/Source/V3World/V3World.cpp
+++ b/EU4ToVic3/Source/V3World/V3World.cpp
@@ -181,6 +181,7 @@ V3::World::World(const Configuration& configuration, const EU4::World& sourceWor
 	politicalManager.generateAIStrategies(clayManager);
 	politicalManager.generateAISecretGoals(clayManager);
 	Log(LogLevel::Progress) << "70 %";
+	popManager.liberateSlaves(politicalManager);
 	popManager.alterSlaveCultures(politicalManager, clayManager, cultureMapper.getV3CultureDefinitions());
 
 	politicalManager.incorporateStates(cultureMapper, clayManager);


### PR DESCRIPTION
Victoria 3 frees the slaves when the "Slavery Banned" law is adopted, but does not (AFAICT) check for consistency; if a country has both Slavery Banned and some actual slaves, those POPs will just go on being slaves. This change sets the type of any slave POPs in countries with `law_slavery_banned` to "".