### PR TITLE
Overpopulation building tweak

### DIFF
--- a/EU4ToVic3/Source/V3World/ClayManager/State/SubState.h
+++ b/EU4ToVic3/Source/V3World/ClayManager/State/SubState.h
@@ -112,6 +112,7 @@ class SubState
 	[[nodiscard]] const auto& getInfrastructure() const { return infrastructure; }
 	[[nodiscard]] int getResource(const std::string& theResource) const;
 	[[nodiscard]] double getTerrainFrequency(const std::string& theTerrain) const;
+	[[nodiscard]] double getOverPopulation() const;
 	[[nodiscard]] const auto& getTerrainFrequencies() { return terrainFrequency; }
 	[[nodiscard]] const auto& getDemographics() const { return demographics; }
 	[[nodiscard]] const auto& getSubStatePops() const { return subStatePops; }
@@ -173,6 +174,7 @@ class SubState
 	[[nodiscard]] double calcBuildingInvestmentWeight(const Building& building) const;
 	[[nodiscard]] double calcBuildingIndustrialWeight(const Building& building, const BuildingGroups& buildingGroups) const;
 	[[nodiscard]] double calcBuildingIncorporationWeight(const Building& building, const BuildingGroups& buildingGroups) const;
+	[[nodiscard]] double calcBuildingOverPopulationWeight(const Building& building, const BuildingGroups& buildingGroups) const;
 	[[nodiscard]] bool isBuildingValid(const Building& building,
 		 const BuildingGroups& buildingGroups,
 		 const std::map<std::string, Law>& lawsMap,

--- a/EU4ToVic3/Source/V3World/EconomyManager/Building/BuildingGroup.cpp
+++ b/EU4ToVic3/Source/V3World/EconomyManager/Building/BuildingGroup.cpp
@@ -18,7 +18,11 @@ void V3::BuildingGroup::registerKeys()
 		resourceCapped = (commonItems::getString(theStream) == "yes");
 	});
 	registerKeyword("land_usage", [this](std::istream& theStream) {
-		resourceCapped = (commonItems::getString(theStream) == "rural");
+		arableCapped = (commonItems::getString(theStream) == "rural");
+		if (arableCapped)
+		{
+			resourceCapped = true;
+		}
 	});
 	registerKeyword("parent_group", [this](std::istream& theStream) {
 		parent = commonItems::getString(theStream);

--- a/EU4ToVic3/Source/V3World/EconomyManager/Building/BuildingGroup.h
+++ b/EU4ToVic3/Source/V3World/EconomyManager/Building/BuildingGroup.h
@@ -18,7 +18,7 @@ class BuildingGroup: commonItems::parser
 	[[nodiscard]] const auto& getCategory() const { return category; }
 	[[nodiscard]] const auto& getInfrastructureCost() const { return infrastructureCost; }
 	[[nodiscard]] const auto& possibleIsResourceCapped() const { return resourceCapped; }
-
+	[[nodiscard]] const auto& usesArableLand() const { return arableCapped; }
 
   private:
 	void registerKeys();
@@ -27,6 +27,7 @@ class BuildingGroup: commonItems::parser
 	std::optional<std::string> category;
 	std::optional<double> infrastructureCost;
 	std::optional<bool> resourceCapped;
+	std::optional<bool> arableCapped;
 };
 } // namespace V3
 

--- a/EU4ToVic3/Source/V3World/EconomyManager/Building/BuildingGroups.cpp
+++ b/EU4ToVic3/Source/V3World/EconomyManager/Building/BuildingGroups.cpp
@@ -33,6 +33,66 @@ void V3::BuildingGroups::addBuildingGroup(const std::shared_ptr<BuildingGroup>& 
 	buildingGroups[theBuildingGroup->getName()] = theBuildingGroup;
 }
 
+std::optional<std::string> V3::BuildingGroups::getAncestralCategory(const std::optional<std::string>& theGroupName) const
+{
+	if (!theGroupName)
+	{
+		return std::nullopt;
+	}
+	auto name = theGroupName.value();
+	while (!name.empty())
+	{
+		const auto& possibleGroup = buildingGroups.find(name);
+		if (possibleGroup == buildingGroups.end())
+		{
+			break;
+		}
+                const auto cat = possibleGroup->second->getCategory();
+		if (cat)
+		{
+			return *cat;
+		}
+		const auto& parentName = possibleGroup->second->getParentName();
+		if (!parentName)
+		{
+			break;
+		}
+		name = parentName.value();
+	}
+
+	return std::nullopt;
+}
+
+bool V3::BuildingGroups::usesArableLand(const std::optional<std::string>& theGroupName) const
+{
+	if (!theGroupName)
+	{
+		return false;
+	}
+	auto name = theGroupName.value();
+	while (!name.empty())
+	{
+		const auto& possibleGroup = buildingGroups.find(name);
+		if (possibleGroup == buildingGroups.end())
+		{
+			break;
+		}
+                const auto& cat = possibleGroup->second->getCategory();
+		if (possibleGroup->second->usesArableLand())
+		{
+			return true;
+		}
+		const auto& parentName = possibleGroup->second->getParentName();
+		if (!parentName)
+		{
+			break;
+		}
+		name = parentName.value();
+	}
+
+	return false;
+}
+
 std::optional<std::string> V3::BuildingGroups::tryGetParentName(const std::optional<std::string>& theGroupName) const
 {
 	if (!theGroupName)

--- a/EU4ToVic3/Source/V3World/EconomyManager/Building/BuildingGroups.h
+++ b/EU4ToVic3/Source/V3World/EconomyManager/Building/BuildingGroups.h
@@ -13,10 +13,12 @@ class BuildingGroups
 	void setInfrastructureCosts();
 	void setResourceCaps();
 
+	[[nodiscard]] std::optional<std::string> getAncestralCategory(const std::optional<std::string>& theGroupName) const;
 	[[nodiscard]] const auto& getBuildingGroupMap() const { return buildingGroups; }
 	[[nodiscard]] std::optional<std::string> tryGetParentName(const std::optional<std::string>& theGroupName) const;
 	[[nodiscard]] std::optional<double> tryGetInfraCost(const std::optional<std::string>& theGroupName) const;
 	[[nodiscard]] std::optional<bool> tryGetIsCapped(const std::optional<std::string>& theGroupName) const;
+	[[nodiscard]] bool usesArableLand(const std::optional<std::string>& theGroupName) const;
 
   private:
 	std::map<std::string, std::shared_ptr<BuildingGroup>> buildingGroups;

--- a/EU4ToVic3/Source/V3World/EconomyManager/EconomyManager.cpp
+++ b/EU4ToVic3/Source/V3World/EconomyManager/EconomyManager.cpp
@@ -285,17 +285,20 @@ std::pair<double, double> V3::EconomyManager::civLevelCountryBudgets() const
 	double accumulatedWeight = 0;
 	double totalCivLevel = 0.0;
 	const double geoMeanPop = calculateGeoMeanCentralizedPops();
-	// while determining individual country's industry score, accumulate total industry factor & weight
+	// While determining individual countries' industry scores, accumulate total industry factor and weight.
 
 	for (const auto& country: centralizedCountries)
 	{
 		const int popCount = country->getPopCount();
-		country->setIndustryWeight(popCount * (country->getProcessedData().civLevel / 100) * calculatePopDistanceFactor(popCount, geoMeanPop));
+		double weight = popCount * (country->getProcessedData().civLevel * 0.01);
+		weight *= calculatePopDistanceFactor(popCount, geoMeanPop);
+		weight *= country->getOverPopulation();
+		country->setIndustryWeight(weight);
 		accumulatedWeight += country->getIndustryWeight();
 		totalCivLevel += country->getProcessedData().civLevel;
 	}
 
-	// adjust global total by average industry factor compared to baseline
+	// Adjust global total by average industry factor compared to baseline.
 	const double globalIndustryFactor = (totalCivLevel / static_cast<double>(centralizedCountries.size()) / econDefines.getMeanCivlevel()) - 1;
 
 	Log(LogLevel::Info) << std::fixed << std::setprecision(0) << "<> The world is " << (globalIndustryFactor + 1) * 100

--- a/EU4ToVic3/Source/V3World/PoliticalManager/Country/Country.cpp
+++ b/EU4ToVic3/Source/V3World/PoliticalManager/Country/Country.cpp
@@ -600,6 +600,28 @@ double V3::Country::getTotalDev() const
 	});
 }
 
+double V3::Country::getOverPopulation() const
+{
+	double pops = 0;
+	double capacity = 0;
+	for (const auto& subState: subStates)
+	{
+		pops += subState->getSubStatePops().getPopCount();
+		capacity += subState->getResource("bg_agriculture");
+	}
+	capacity *= 5000;
+	if (capacity < 5000)
+	{
+		return 10.0;
+	}
+	const auto ratio = pops / capacity;
+	if (ratio < 1.0)
+	{
+		return 1.0;
+	}
+	return ratio;
+}
+
 void V3::Country::determineWesternizationWealthAndLiteracy(double topTech,
 	 double topInstitutions,
 	 const mappers::CultureMapper& cultureMapper,

--- a/EU4ToVic3/Source/V3World/PoliticalManager/Country/Country.h
+++ b/EU4ToVic3/Source/V3World/PoliticalManager/Country/Country.h
@@ -167,6 +167,7 @@ class Country: commonItems::parser
 	[[nodiscard]] std::string getName(const std::string& language) const;
 	[[nodiscard]] std::string getAdjective(const std::string& language) const;
 	[[nodiscard]] double getTotalDev() const;
+	[[nodiscard]] double getOverPopulation() const;
 	[[nodiscard]] int getPopCount() const;
 	[[nodiscard]] int getVanillaPopCount() const; // vanilla pop count of all the provinces this country holds
 	[[nodiscard]] int getIncorporatedPopCount() const;


### PR DESCRIPTION
This PR increases the building weight of overpopulated countries, that is, countries with more POPs than their arable land can support; and also increases the weight for non-agricultural buildings (ones that don't use arable land) in overpopulated states. This somewhat mitigates the starvation issue when a few states are drastically more developed than the rest of their region.