### PR TITLE
Fix misspelling of peasant levy law in building multiplier.

### DIFF
--- a/EU4ToVic3/Data_Files/configurables/economy/national_budget.txt
+++ b/EU4ToVic3/Data_Files/configurables/economy/national_budget.txt
@@ -18,7 +18,7 @@
 # Every vic3_building possible to start the game with should belong to one and only one sector.
 # example_sector = {
 #    weight = 4 # Base weight of the sector
-#    industrial = yes # wieght is modified by civlevel and industry score (see configurables/westernization.txt)
+#    industrial = yes # weight is modified by civlevel and industry score (see configurables/westernization.txt)
 #
 #    building_1 # Anytime a state builds building_1, the cost is taken from example_sector budget
 #    building_2 # Anytime a state builds building_2, the cost is taken from example_sector budget
@@ -53,7 +53,7 @@ military = {
     }
     multiply = {
         value = 1.5
-        vic3_law = law_peasant_levy
+        vic3_law = law_peasant_levies
     }
 }
 


### PR DESCRIPTION
It's `levies` everywhere else in the files so it should presumably be the same in the building weight modifier.