### PR TITLE
Colonial cultures preliminary update

### DIFF
--- a/EU4ToVic3/Data_Files/blankMod/output/common/decisions/canada_australia.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/decisions/canada_australia.txt
@@ -1,10 +1,12 @@
 ﻿canada_unite_can = {
 	is_shown = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }		##Converter
+		capital = { zzz_converter_state_is_in_canada = yes }									##Converter
 		is_subject = yes
 		any_neighbouring_state = {
 			owner = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }		##Converter
+				capital = { zzz_converter_state_is_in_canada = yes }									##Converter
 				is_subject = yes
 				NOT = { THIS = ROOT }
 				top_overlord = {
@@ -28,6 +30,7 @@
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }		##Converter
+					capital = { zzz_converter_state_is_in_canada = yes }									##Converter
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -62,6 +65,7 @@ canada_unite_gbr = {
 	is_shown = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }		##Converter
+			capital = { zzz_converter_state_is_in_canada = yes }									##Converter
 			is_ai = yes
 			count >= 2
 		}
@@ -74,6 +78,7 @@ canada_unite_gbr = {
 			text = gbr_can_relations_tt
 			any_subject_or_below = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }		##Converter
+				capital = { zzz_converter_state_is_in_canada = yes }									##Converter
 				is_ai = yes
 				relations:root >= relations_threshold:amicable
 				count >= 2
@@ -103,10 +108,12 @@ canada_unite_gbr = {
 australia_unite_aus = {
 	is_shown = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
+		capital = { zzz_converter_state_is_in_australia = yes }										##Converter
 		is_subject = yes
 		any_neighbouring_state = {
 			owner = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
+				capital = { zzz_converter_state_is_in_australia = yes }									##Converter
 				is_ai = yes
 				is_subject = yes
 				NOT = { THIS = ROOT }
@@ -130,6 +137,7 @@ australia_unite_aus = {
 				owner = {
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
+					capital = { zzz_converter_state_is_in_australia = yes }										##Converter
 					is_ai = yes
 					is_subject = yes
 					NOT = { THIS = ROOT }
@@ -165,6 +173,7 @@ australia_unite_gbr = {
 	is_shown = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
+			capital = { zzz_converter_state_is_in_australia = yes }										##Converter
 			is_ai = yes
 			count >= 2
 		}
@@ -177,6 +186,7 @@ australia_unite_gbr = {
 			text = gbr_aus_relations_tt
 			any_subject_or_below = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
+				capital = { zzz_converter_state_is_in_australia = yes }									##Converter
 				is_ai = yes
 				relations:root >= relations_threshold:amicable
 				count >= 2

--- a/EU4ToVic3/Data_Files/blankMod/output/common/decisions/zzz_converter_confederation_decisions.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/decisions/zzz_converter_confederation_decisions.txt
@@ -1,6 +1,7 @@
 ﻿america_unite_usa = {
 	is_shown = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_american_cultures target = this } }
+		capital = { zzz_converter_state_is_in_america = yes }
 		is_subject = yes
 		any_neighbouring_state = {
 			owner = {
@@ -28,6 +29,7 @@
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_american_cultures target = this } }
+					capital = { zzz_converter_state_is_in_america = yes }
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -62,6 +64,7 @@ america_unite_gbr = {
 	is_shown = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_american_cultures target = this } }
+			capital = { zzz_converter_state_is_in_america = yes }
 			is_ai = yes
 			count >= 2
 		}
@@ -74,6 +77,7 @@ america_unite_gbr = {
 			text = gbr_usa_relations_tt
 			any_subject_or_below = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_american_cultures target = this } }
+				capital = { zzz_converter_state_is_in_america = yes }
 				is_ai = yes
 				relations:root >= relations_threshold:amicable
 				count >= 2
@@ -103,10 +107,12 @@ america_unite_gbr = {
 california_unite_cal = {
 	is_shown = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_californian_cultures target = this } }
+		capital = { zzz_converter_state_is_in_california = yes }
 		is_subject = yes
 		any_neighbouring_state = {
 			owner = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_californian_cultures target = this } }
+				capital = { zzz_converter_state_is_in_california = yes }
 				is_ai = yes
 				is_subject = yes
 				NOT = { THIS = ROOT }
@@ -130,6 +136,7 @@ california_unite_cal = {
 				owner = {
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_californian_cultures target = this } }
+					capital = { zzz_converter_state_is_in_california = yes }
 					is_ai = yes
 					is_subject = yes
 					NOT = { THIS = ROOT }
@@ -165,6 +172,7 @@ california_unite_gbr = {
 	is_shown = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_californian_cultures target = this } }
+			capital = { zzz_converter_state_is_in_california = yes }
 			is_ai = yes
 			count >= 2
 		}
@@ -177,6 +185,7 @@ california_unite_gbr = {
 			text = gbr_cal_relations_tt
 			any_subject_or_below = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_californian_cultures target = this } }
+				capital = { zzz_converter_state_is_in_california = yes }
 				is_ai = yes
 				relations:root >= relations_threshold:amicable
 				count >= 2
@@ -206,10 +215,12 @@ california_unite_gbr = {
 mexico_unite_mex = {
 	is_shown = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_mexican_cultures target = this } }
+		capital = { zzz_converter_state_is_in_mexico = yes }
 		is_subject = yes
 		any_neighbouring_state = {
 			owner = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_mexican_cultures target = this } }
+				capital = { zzz_converter_state_is_in_mexico = yes }
 				is_subject = yes
 				NOT = { THIS = ROOT }
 				top_overlord = {
@@ -233,6 +244,7 @@ mexico_unite_mex = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_mexican_cultures target = this } }
+					capital = { zzz_converter_state_is_in_mexico = yes }
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -267,6 +279,7 @@ mexico_unite_gbr = {
 	is_shown = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_mexican_cultures target = this } }
+			capital = { zzz_converter_state_is_in_mexico = yes }
 			is_ai = yes
 			count >= 2
 		}
@@ -279,6 +292,7 @@ mexico_unite_gbr = {
 			text = gbr_mex_relations_tt
 			any_subject_or_below = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_mexican_cultures target = this } }
+				capital = { zzz_converter_state_is_in_mexico = yes }
 				is_ai = yes
 				relations:root >= relations_threshold:amicable
 				count >= 2
@@ -308,10 +322,12 @@ mexico_unite_gbr = {
 colombia_unite_gco = {
 	is_shown = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_colombian_cultures target = this } }
+		capital = { zzz_converter_state_is_in_gran_colombia = yes }
 		is_subject = yes
 		any_neighbouring_state = {
 			owner = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_colombian_cultures target = this } }
+				capital = { zzz_converter_state_is_in_gran_colombia = yes }
 				is_subject = yes
 				NOT = { THIS = ROOT }
 				top_overlord = {
@@ -335,6 +351,7 @@ colombia_unite_gco = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_colombian_cultures target = this } }
+					capital = { zzz_converter_state_is_in_gran_colombia = yes }
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -369,6 +386,7 @@ colombia_unite_gbr = {
 	is_shown = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_colombian_cultures target = this } }
+			capital = { zzz_converter_state_is_in_gran_colombia = yes }
 			is_ai = yes
 			count >= 2
 		}
@@ -381,6 +399,7 @@ colombia_unite_gbr = {
 			text = gbr_gco_relations_tt
 			any_subject_or_below = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_colombian_cultures target = this } }
+				capital = { zzz_converter_state_is_in_gran_colombia = yes }
 				is_ai = yes
 				relations:root >= relations_threshold:amicable
 				count >= 2
@@ -410,10 +429,12 @@ colombia_unite_gbr = {
 peru_unite_peu = {
 	is_shown = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_andean_cultures target = this } }
+		capital = { region = sr:region_andes }
 		is_subject = yes
 		any_neighbouring_state = {
 			owner = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_andean_cultures target = this } }
+				capital = { region = sr:region_andes }
 				is_ai = yes
 				is_subject = yes
 				NOT = { THIS = ROOT }
@@ -437,6 +458,7 @@ peru_unite_peu = {
 				owner = {
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_andean_cultures target = this } }
+					capital = { region = sr:region_andes }
 					is_ai = yes
 					is_subject = yes
 					NOT = { THIS = ROOT }
@@ -472,6 +494,7 @@ peru_unite_gbr = {
 	is_shown = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_andean_cultures target = this } }
+			capital = { region = sr:region_andes }
 			is_ai = yes
 			count >= 2
 		}
@@ -484,6 +507,7 @@ peru_unite_gbr = {
 			text = gbr_peu_relations_tt
 			any_subject_or_below = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_andean_cultures target = this } }
+				capital = { region = sr:region_andes }
 				is_ai = yes
 				relations:root >= relations_threshold:amicable
 				count >= 2
@@ -513,10 +537,12 @@ peru_unite_gbr = {
 brazil_unite_brz = {
 	is_shown = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_brazilian_cultures target = this } }
+		capital = { region = sr:region_brazil }
 		is_subject = yes
 		any_neighbouring_state = {
 			owner = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_brazilian_cultures target = this } }
+				capital = { region = sr:region_brazil }
 				is_subject = yes
 				NOT = { THIS = ROOT }
 				top_overlord = {
@@ -540,6 +566,7 @@ brazil_unite_brz = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_brazilian_cultures target = this } }
+					capital = { region = sr:region_brazil }
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -574,6 +601,7 @@ brazil_unite_gbr = {
 	is_shown = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_brazilian_cultures target = this } }
+			capital = { region = sr:region_brazil }
 			is_ai = yes
 			count >= 2
 		}
@@ -586,6 +614,7 @@ brazil_unite_gbr = {
 			text = gbr_brz_relations_tt
 			any_subject_or_below = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_brazilian_cultures target = this } }
+				capital = { region = sr:region_brazil }
 				is_ai = yes
 				relations:root >= relations_threshold:amicable
 				count >= 2
@@ -615,10 +644,12 @@ brazil_unite_gbr = {
 argentina_unite_arg = {
 	is_shown = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_platinean_cultures target = this } }
+		capital = { zzz_converter_state_is_in_argentina = yes }
 		is_subject = yes
 		any_neighbouring_state = {
 			owner = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_platinean_cultures target = this } }
+				capital = { zzz_converter_state_is_in_argentina = yes }
 				is_ai = yes
 				is_subject = yes
 				NOT = { THIS = ROOT }
@@ -642,6 +673,7 @@ argentina_unite_arg = {
 				owner = {
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_platinean_cultures target = this } }
+					capital = { zzz_converter_state_is_in_argentina = yes }
 					is_ai = yes
 					is_subject = yes
 					NOT = { THIS = ROOT }
@@ -677,6 +709,7 @@ argentina_unite_gbr = {
 	is_shown = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_platinean_cultures target = this } }
+			capital = { zzz_converter_state_is_in_argentina = yes }
 			is_ai = yes
 			count >= 2
 		}
@@ -689,6 +722,7 @@ argentina_unite_gbr = {
 			text = gbr_arg_relations_tt
 			any_subject_or_below = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_platinean_cultures target = this } }
+				capital = { zzz_converter_state_is_in_argentina = yes }
 				is_ai = yes
 				relations:root >= relations_threshold:amicable
 				count >= 2
@@ -718,10 +752,12 @@ argentina_unite_gbr = {
 cape_unite_saf = {
 	is_shown = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_cape_cultures target = this } }
+		capital = { region = sr:region_southern_africa }
 		is_subject = yes
 		any_neighbouring_state = {
 			owner = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_cape_cultures target = this } }
+				capital = { region = sr:region_southern_africa }
 				is_ai = yes
 				is_subject = yes
 				NOT = { THIS = ROOT }
@@ -745,6 +781,7 @@ cape_unite_saf = {
 				owner = {
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_cape_cultures target = this } }
+					capital = { region = sr:region_southern_africa }
 					is_ai = yes
 					is_subject = yes
 					NOT = { THIS = ROOT }
@@ -780,6 +817,7 @@ cape_unite_gbr = {
 	is_shown = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_cape_cultures target = this } }
+			capital = { region = sr:region_southern_africa }
 			is_ai = yes
 			count >= 2
 		}
@@ -792,6 +830,7 @@ cape_unite_gbr = {
 			text = gbr_saf_relations_tt
 			any_subject_or_below = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_cape_cultures target = this } }
+				capital = { region = sr:region_southern_africa }
 				is_ai = yes
 				relations:root >= relations_threshold:amicable
 				count >= 2

--- a/EU4ToVic3/Data_Files/blankMod/output/common/ideologies/00_leader_ideologies.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/ideologies/00_leader_ideologies.txt
@@ -963,7 +963,7 @@ ideology_abolitionist = {
 				religion = { has_discrimination_trait = mazdan }
 				owner = {
 					religion = {
-						NOT = { has_discrimination_trait = ﻿mazdan }
+						NOT = { has_discrimination_trait = mazdan }
 					}
 				}
 			}

--- a/EU4ToVic3/Data_Files/blankMod/output/common/journal_entries/00_canada_australia.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/journal_entries/00_canada_australia.txt
@@ -3,6 +3,7 @@
 
 	is_shown_when_inactive = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }			##Converter
+		capital = { zzz_converter_state_is_in_canada = yes }										##Converter
 		NOT = { is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_CAN } }		##Converter
 		is_subject = yes
 	}
@@ -47,10 +48,12 @@ je_canada_gbr = {
 	is_shown_when_inactive = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }		##Converter
+			capital = { zzz_converter_state_is_in_canada = yes }									##Converter
 			count >= 2
 		}
 		NOT = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }		##Converter
+			capital = { zzz_converter_state_is_in_canada = yes }									##Converter
 			is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_CAN }			##Converter
 		}
 	}
@@ -92,6 +95,7 @@ je_australia_aus = {
 
 	is_shown_when_inactive = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
+		capital = { zzz_converter_state_is_in_australia = yes }										##Converter
 		NOT = { is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_AST } }			##Converter
 		is_subject = yes
 	}
@@ -132,11 +136,13 @@ je_australia_gbr = {
 	is_shown_when_inactive = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
+			capital = { zzz_converter_state_is_in_australia = yes }										##Converter
 			count >= 2
 		}
 		NOT = {
 			OR = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
+				capital = { zzz_converter_state_is_in_australia = yes }										##Converter
 				is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_AST }				##Converter
 			}
 		}

--- a/EU4ToVic3/Data_Files/blankMod/output/common/journal_entries/zzz_converter_confederation_je.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/journal_entries/zzz_converter_confederation_je.txt
@@ -3,6 +3,7 @@
 
 	is_shown_when_inactive = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_american_cultures target = this } }
+		capital = { zzz_converter_state_is_in_america = yes }
 		NOT = { is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_USA } }
 		is_subject = yes
 	}
@@ -70,10 +71,12 @@ je_america_gbr = {
 	is_shown_when_inactive = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_american_cultures target = this } }
+			capital = { zzz_converter_state_is_in_america = yes }
 			count >= 2
 		}
 		NOT = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_american_cultures target = this } }
+			capital = { zzz_converter_state_is_in_america = yes }
 			is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_USA }
 		}
 	}
@@ -138,6 +141,7 @@ je_california_cal = {
 
 	is_shown_when_inactive = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_californian_cultures target = this } }
+		capital = { zzz_converter_state_is_in_california = yes }
 		NOT = { is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_CAL } }
 		is_subject = yes
 	}
@@ -184,10 +188,12 @@ je_california_gbr = {
 	is_shown_when_inactive = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_californian_cultures target = this } }
+			capital = { zzz_converter_state_is_in_california = yes }
 			count >= 2
 		}
 		NOT = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_californian_cultures target = this } }
+			capital = { zzz_converter_state_is_in_california = yes }
 			is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_CAL }
 		}
 	}
@@ -233,6 +239,7 @@ je_mexico_mex = {
 
 	is_shown_when_inactive = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_mexican_cultures target = this } }
+		capital = { zzz_converter_state_is_in_mexico = yes }
 		NOT = { is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_MEX } }
 		is_subject = yes
 	}
@@ -286,10 +293,12 @@ je_mexico_gbr = {
 	is_shown_when_inactive = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_mexican_cultures target = this } }
+			capital = { zzz_converter_state_is_in_mexico = yes }
 			count >= 2
 		}
 		NOT = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_mexican_cultures target = this } }
+			capital = { zzz_converter_state_is_in_mexico = yes }
 			is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_MEX }
 		}
 	}
@@ -340,6 +349,7 @@ je_colombia_gco = {
 
 	is_shown_when_inactive = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_colombian_cultures target = this } }
+		capital = { zzz_converter_state_is_in_gran_colombia = yes }
 		NOT = { is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_GCO } }
 		is_subject = yes
 	}
@@ -380,10 +390,12 @@ je_colombia_gbr = {
 	is_shown_when_inactive = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_colombian_cultures target = this } }
+			capital = { zzz_converter_state_is_in_gran_colombia = yes }
 			count >= 2
 		}
 		NOT = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_colombian_cultures target = this } }
+			capital = { zzz_converter_state_is_in_gran_colombia = yes }
 			is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_GCO }
 		}
 	}
@@ -423,6 +435,7 @@ je_peru_peu = {
 
 	is_shown_when_inactive = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_andean_cultures target = this } }
+		capital = { region = sr:region_andes }
 		NOT = { is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_PEU } }
 		is_subject = yes
 	}
@@ -469,10 +482,12 @@ je_peru_gbr = {
 	is_shown_when_inactive = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_andean_cultures target = this } }
+			capital = { region = sr:region_andes }
 			count >= 2
 		}
 		NOT = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_andean_cultures target = this } }
+			capital = { region = sr:region_andes }
 			is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_PEU }
 		}
 	}
@@ -516,6 +531,7 @@ je_brazil_brz = {
 
 	is_shown_when_inactive = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_brazilian_cultures target = this } }
+		capital = { region = sr:region_brazil }
 		NOT = { is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_BRZ } }
 		is_subject = yes
 	}
@@ -565,10 +581,12 @@ je_brazil_gbr = {
 	is_shown_when_inactive = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_brazilian_cultures target = this } }
+			capital = { region = sr:region_brazil }
 			count >= 2
 		}
 		NOT = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_brazilian_cultures target = this } }
+			capital = { region = sr:region_brazil }
 			is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_BRZ }
 		}
 	}
@@ -617,6 +635,7 @@ je_argentina_arg = {
 
 	is_shown_when_inactive = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_platinean_cultures target = this } }
+		capital = { zzz_converter_state_is_in_argentina = yes }
 		NOT = { is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_ARG } }
 		is_subject = yes
 	}
@@ -663,10 +682,12 @@ je_argentina_gbr = {
 	is_shown_when_inactive = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_platinean_cultures target = this } }
+			capital = { zzz_converter_state_is_in_argentina = yes }
 			count >= 2
 		}
 		NOT = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_platinean_cultures target = this } }
+			capital = { zzz_converter_state_is_in_argentina = yes }
 			is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_ARG }
 		}
 	}
@@ -710,6 +731,7 @@ je_cape_saf = {
 
 	is_shown_when_inactive = {
 		any_primary_culture = { is_target_in_global_variable_list = { name = global_cape_cultures target = this } }
+		capital = { region = sr:region_southern_africa }
 		NOT = { is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_SAF } }
 		is_subject = yes
 	}
@@ -748,10 +770,12 @@ je_cape_gbr = {
 	is_shown_when_inactive = {
 		any_subject_or_below = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_cape_cultures target = this } }
+			capital = { region = sr:region_southern_africa }
 			count >= 2
 		}
 		NOT = {
 			any_primary_culture = { is_target_in_global_variable_list = { name = global_cape_cultures target = this } }
+			capital = { region = sr:region_southern_africa }
 			is_target_in_global_variable_list = { name = global_unavailable_converter_confederations target = flag:converter_SAF }
 		}
 	}

--- a/EU4ToVic3/Data_Files/blankMod/output/common/on_actions/zzz_ig_on_actions.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/on_actions/zzz_ig_on_actions.txt
@@ -9,7 +9,7 @@ on_yearly_pulse_country = {
 	}
 }
 
-﻿# Root = Releasing Country
+# Root = Releasing Country
 # scope:target = Released Country
 on_country_released_as_own_subject = {
 	effect = {

--- a/EU4ToVic3/Data_Files/blankMod/output/common/scripted_triggers/zzz_converter_geography_triggers.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/scripted_triggers/zzz_converter_geography_triggers.txt
@@ -12,9 +12,10 @@
 # is_settler_colonial_country
 # is_colonized_country
 
-﻿zzz_converter_state_is_in_canada = {
+zzz_converter_state_is_in_canada = {
 	OR = {
 		region = sr:region_canada
+		state_region = s:STATE_NEW_BRUNSWICK
 		state_region = s:STATE_SASKATCHEWAN
 		state_region = s:STATE_ALBERTA
 		state_region = s:STATE_BRITISH_COLUMBIA

--- a/EU4ToVic3/Data_Files/blankMod/output/events/canada_australia_events.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/events/canada_australia_events.txt
@@ -29,6 +29,7 @@ can_aus.1 = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }		##Converter
+					capital = { zzz_converter_state_is_in_canada = yes }								##Converter
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -80,6 +81,7 @@ can_aus.2 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }		##Converter
+				capital = { zzz_converter_state_is_in_canada = yes }									##Converter
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 			}
@@ -88,6 +90,7 @@ can_aus.2 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }		##Converter
+				capital = { zzz_converter_state_is_in_canada = yes }									##Converter
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 				NOT = {
@@ -146,6 +149,7 @@ can_aus.3 = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
+					capital = { zzz_converter_state_is_in_australia = yes }										##Converter
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -200,6 +204,7 @@ can_aus.4 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
+				capital = { zzz_converter_state_is_in_australia = yes }										##Converter
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 			}
@@ -208,6 +213,7 @@ can_aus.4 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
+				capital = { zzz_converter_state_is_in_australia = yes }										##Converter
 				relations:root >= relations_threshold:amicable
 				NOT = {
 					scope:canada_scope_1 = THIS
@@ -363,10 +369,8 @@ can_aus.6 = {
 	immediate = {
 		random_subject_or_below = {
 			limit = {
-				OR = {
-					any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }		##Converter
-					has_journal_entry = je_canada_can		##Converter
-				}
+				any_primary_culture = { is_target_in_global_variable_list = { name = global_canadian_cultures target = this } }		##Converter
+				capital = { zzz_converter_state_is_in_canada = yes }										##Converter
 				any_scope_state = {
 					OR = {
 						state_region = s:STATE_ONTARIO
@@ -573,11 +577,8 @@ can_aus.8 = {
 	immediate = {
 		random_subject_or_below = {
 			limit = {
-				OR = {
-					any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
-					has_journal_entry = je_australia_aus		##Converter
-					country_has_primary_culture = cu:maori
-				}
+				any_primary_culture = { is_target_in_global_variable_list = { name = global_australian_cultures target = this } }		##Converter
+				capital = { zzz_converter_state_is_in_australia = yes }										##Converter
 				any_scope_state = {
 					OR = {
 						state_region = s:STATE_NEW_SOUTH_WALES

--- a/EU4ToVic3/Data_Files/blankMod/output/events/zzz_converter_confederation_events.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/events/zzz_converter_confederation_events.txt
@@ -29,6 +29,7 @@ zzz_cc_confederation.1 = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_american_cultures target = this } }
+					capital = { zzz_converter_state_is_in_america = yes }
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -80,6 +81,7 @@ zzz_cc_confederation.2 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_american_cultures target = this } }
+				capital = { zzz_converter_state_is_in_america = yes }
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 			}
@@ -88,6 +90,7 @@ zzz_cc_confederation.2 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_american_cultures target = this } }
+				capital = { zzz_converter_state_is_in_america = yes }
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 				NOT = {
@@ -146,6 +149,7 @@ zzz_cc_confederation.3 = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_californian_cultures target = this } }
+					capital = { zzz_converter_state_is_in_california = yes }
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -200,6 +204,7 @@ zzz_cc_confederation.4 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_californian_cultures target = this } }
+				capital = { zzz_converter_state_is_in_california = yes }
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 			}
@@ -208,6 +213,7 @@ zzz_cc_confederation.4 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_californian_cultures target = this } }
+				capital = { zzz_converter_state_is_in_california = yes }
 				relations:root >= relations_threshold:amicable
 				NOT = {
 					scope:canada_scope_1 = THIS
@@ -361,6 +367,7 @@ zzz_cc_confederation.6 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_american_cultures target = this } }
+				capital = { zzz_converter_state_is_in_america = yes }
 				any_scope_state = {
 					OR = {
 						state_region = s:STATE_MASSACHUSETTS
@@ -587,6 +594,7 @@ zzz_cc_confederation.8 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_californian_cultures target = this } }
+				capital = { zzz_converter_state_is_in_california = yes }
 				any_scope_state = {
 					OR = {
 						state_region = s:STATE_WASHINGTON
@@ -699,6 +707,7 @@ zzz_cc_confederation.9 = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_mexican_cultures target = this } }
+					capital = { zzz_converter_state_is_in_mexico = yes }
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -750,6 +759,7 @@ zzz_cc_confederation.10 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_mexican_cultures target = this } }
+				capital = { zzz_converter_state_is_in_mexico = yes }
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 			}
@@ -758,6 +768,7 @@ zzz_cc_confederation.10 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_mexican_cultures target = this } }
+				capital = { zzz_converter_state_is_in_mexico = yes }
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 				NOT = {
@@ -816,6 +827,7 @@ zzz_cc_confederation.11 = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_colombian_cultures target = this } }
+					capital = { zzz_converter_state_is_in_gran_colombia = yes }
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -870,6 +882,7 @@ zzz_cc_confederation.12 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_colombian_cultures target = this } }
+				capital = { zzz_converter_state_is_in_gran_colombia = yes }
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 			}
@@ -878,6 +891,7 @@ zzz_cc_confederation.12 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_colombian_cultures target = this } }
+				capital = { zzz_converter_state_is_in_gran_colombia = yes }
 				relations:root >= relations_threshold:amicable
 				NOT = {
 					scope:canada_scope_1 = THIS
@@ -1031,6 +1045,7 @@ zzz_cc_confederation.14 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_mexican_cultures target = this } }
+				capital = { zzz_converter_state_is_in_mexico = yes }
 				any_scope_state = {
 					OR = {
 						state_region = s:STATE_JALISCO
@@ -1243,6 +1258,7 @@ zzz_cc_confederation.16 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_colombian_cultures target = this } }
+				capital = { zzz_converter_state_is_in_gran_colombia = yes }
 				any_scope_state = {
 					OR = {
 						state_region = s:STATE_BOLIVAR
@@ -1349,6 +1365,7 @@ zzz_cc_confederation.17 = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_andean_cultures target = this } }
+					capital = { region = sr:region_andes }
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -1400,6 +1417,7 @@ zzz_cc_confederation.18 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_andean_cultures target = this } }
+				capital = { region = sr:region_andes }
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 			}
@@ -1408,6 +1426,7 @@ zzz_cc_confederation.18 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_andean_cultures target = this } }
+				capital = { region = sr:region_andes }
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 				NOT = {
@@ -1466,6 +1485,7 @@ zzz_cc_confederation.19 = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_brazilian_cultures target = this } }
+					capital = { region = sr:region_brazil }
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -1520,6 +1540,7 @@ zzz_cc_confederation.20 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_brazilian_cultures target = this } }
+				capital = { region = sr:region_brazil }
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 			}
@@ -1528,6 +1549,7 @@ zzz_cc_confederation.20 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_brazilian_cultures target = this } }
+				capital = { region = sr:region_brazil }
 				relations:root >= relations_threshold:amicable
 				NOT = {
 					scope:canada_scope_1 = THIS
@@ -1681,6 +1703,7 @@ zzz_cc_confederation.22 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_andean_cultures target = this } }
+				capital = { region = sr:region_andes }
 				any_scope_state = {
 					OR = {
 						state_region = s:STATE_LIMA
@@ -1886,6 +1909,7 @@ zzz_cc_confederation.24 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_brazilian_cultures target = this } }
+				capital = { region = sr:region_brazil }
 				any_scope_state = {
 					OR = {
 						state_region = s:STATE_PARANA
@@ -2001,6 +2025,7 @@ zzz_cc_confederation.25 = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_platinean_cultures target = this } }
+					capital = { zzz_converter_state_is_in_argentina = yes }
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -2052,6 +2077,7 @@ zzz_cc_confederation.26 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_platinean_cultures target = this } }
+				capital = { zzz_converter_state_is_in_argentina = yes }
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 			}
@@ -2060,6 +2086,7 @@ zzz_cc_confederation.26 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_platinean_cultures target = this } }
+				capital = { zzz_converter_state_is_in_argentina = yes }
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 				NOT = {
@@ -2118,6 +2145,7 @@ zzz_cc_confederation.27 = {
 					is_ai = yes
 					relations:root >= relations_threshold:amicable
 					any_primary_culture = { is_target_in_global_variable_list = { name = global_cape_cultures target = this } }
+					capital = { region = sr:region_southern_africa }
 					is_subject = yes
 					NOT = { THIS = ROOT }
 					top_overlord = {
@@ -2172,6 +2200,7 @@ zzz_cc_confederation.28 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_cape_cultures target = this } }
+				capital = { region = sr:region_southern_africa }
 				relations:root >= relations_threshold:amicable
 				is_ai = yes
 			}
@@ -2180,6 +2209,7 @@ zzz_cc_confederation.28 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_cape_cultures target = this } }
+				capital = { region = sr:region_southern_africa }
 				relations:root >= relations_threshold:amicable
 				NOT = {
 					scope:canada_scope_1 = THIS
@@ -2333,6 +2363,7 @@ zzz_cc_confederation.30 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_platinean_cultures target = this } }
+				capital = { zzz_converter_state_is_in_argentina = yes }
 				any_scope_state = {
 					OR = {
 						state_region = s:STATE_RIO_NEGRO
@@ -2558,6 +2589,7 @@ zzz_cc_confederation.32 = {
 		random_subject_or_below = {
 			limit = {
 				any_primary_culture = { is_target_in_global_variable_list = { name = global_cape_cultures target = this } }
+				capital = { region = sr:region_southern_africa }
 				any_scope_state = {
 					OR = {
 						state_region = s:STATE_CAPE_COLONY


### PR DESCRIPTION
Removed invisible space before zzz_converter_state_is_in_canada that was breaking the trigger
New Brunswick is now included in the zzz_converter_state_is_in_canada trigger
Removed invisible spaces in 00_leader_ideologies.txt & zzz_ig_on_actions.txt that were breaking things
Decisions, journal entries, & events for colonial confederations now require having a capital in the correct region in addition to having a culture in the correct list