### PR TITLE
Fallback to EU4 flags.

### DIFF
--- a/EU4ToVic3/Source/EU4World/World.cpp
+++ b/EU4ToVic3/Source/EU4World/World.cpp
@@ -39,7 +39,7 @@ EU4::World::World(const std::shared_ptr<Configuration>& theConfiguration, const 
 	Log(LogLevel::Progress) << "15 %";
 
 	// With mods loaded we can init stuff that requires them.
-	const auto modFS = commonItems::ModFilesystem(EU4Path, mods);
+	modFS = commonItems::ModFilesystem(EU4Path, mods);
 
 	Log(LogLevel::Info) << "-> Booting Loaders:";
 	Log(LogLevel::Info) << "\t\tRegions";

--- a/EU4ToVic3/Source/EU4World/World.h
+++ b/EU4ToVic3/Source/EU4World/World.h
@@ -35,6 +35,7 @@ class World: commonItems::parser
 	[[nodiscard]] const auto& getDiplomacy() const { return diplomacyParser; }
 	[[nodiscard]] const auto& getEU4Localizations() const { return countryManager.getLocalizationLoader(); }
 	[[nodiscard]] const auto& getDatingData() const { return datingData; }
+	[[nodiscard]] const auto& getEU4ModFS() const { return modFS; }
 
   private:
 	void registerKeys(const std::shared_ptr<Configuration>& theConfiguration, const commonItems::ConverterVersion& converterVersion);
@@ -50,6 +51,7 @@ class World: commonItems::parser
 
 	std::string EU4Path;
 	Mods mods;
+	commonItems::ModFilesystem modFS;
 
 	DatingData datingData;
 

--- a/EU4ToVic3/Source/V3World/FlagCrafter/FlagCrafter.h
+++ b/EU4ToVic3/Source/V3World/FlagCrafter/FlagCrafter.h
@@ -1,6 +1,7 @@
 #ifndef FLAG_CRAFTER
 #define FLAG_CRAFTER
 #include "FlagColorLoader/FlagColorLoader.h"
+#include "ModLoader/ModFilesystem.h"
 #include <map>
 #include <memory>
 #include <optional>
@@ -30,12 +31,15 @@ class FlagCrafter
 
 	void loadAvailableFlags(const std::string& blankModPath, const std::string& vanillaPath);
 	void loadCustomColors(const std::string& filePath);
-	void distributeAvailableFlags(const std::map<std::string, std::shared_ptr<Country>>& countries, const mappers::CountryMapper& countryMapper);
+	void distributeAvailableFlags(const std::map<std::string, std::shared_ptr<Country>>& countries,
+		 const mappers::CountryMapper& countryMapper,
+		 const commonItems::ModFilesystem& eu4ModFS);
 
 	[[nodiscard]] std::optional<std::map<FLAGTYPE, std::string>> getFlagsForEntity(const std::string& name);
 
   private:
 	[[nodiscard]] bool tryAssigningFlagViaValue(const std::shared_ptr<Country>& country, const std::string& value);
+	[[nodiscard]] bool tryAssigningEU4Flag(const std::shared_ptr<Country>& country, const commonItems::ModFilesystem& eu4ModFS);
 	void loadKnownFlags(const std::string& blankModPath, const std::string& vanillaPath);
 	void filterKnownFlags();
 	void craftCustomFlag(const std::shared_ptr<Country>& country);

--- a/EU4ToVic3/Source/V3World/V3World.cpp
+++ b/EU4ToVic3/Source/V3World/V3World.cpp
@@ -165,7 +165,7 @@ V3::World::World(const Configuration& configuration, const EU4::World& sourceWor
 	flagCrafter.loadCustomColors(configuration.getEU4Path() + "/common/custom_country_colors/00_custom_country_colors.txt");
 	flagCrafter.loadAvailableFlags("blankMod/output/common/coat_of_arms/coat_of_arms/", V3Path + "/common/flag_definitions/");
 	Log(LogLevel::Progress) << "64 %";
-	flagCrafter.distributeAvailableFlags(politicalManager.getCountries(), *countryMapper);
+	flagCrafter.distributeAvailableFlags(politicalManager.getCountries(), *countryMapper, sourceWorld.getEU4ModFS());
 
 	Log(LogLevel::Progress) << "65 %";
 	politicalManager.injectDynamicCulturesIntoFormables(cultureMapper);

--- a/EU4ToVic3Tests/V3WorldTests/FlagCrafterTests/FlagCrafterTests.cpp
+++ b/EU4ToVic3Tests/V3WorldTests/FlagCrafterTests/FlagCrafterTests.cpp
@@ -79,7 +79,7 @@ TEST(V3World_FlagNameLoaderTests, FlagsCanBeAssignedViaFlagCodes)
 	countries.emplace(v3Tag, country);
 
 	// now assign flags.
-	flagCrafter.distributeAvailableFlags(countries, countryMapper);
+	flagCrafter.distributeAvailableFlags(countries, countryMapper, commonItems::ModFilesystem());
 
 	// do we have them yet?
 	const auto& flags = country->getFlags();
@@ -112,7 +112,7 @@ TEST(V3World_FlagNameLoaderTests, FlagsCanBeAssignedViaTAGs)
 	countries.emplace(v3Tag, country);
 
 	// now assign flags.
-	flagCrafter.distributeAvailableFlags(countries, countryMapper);
+	flagCrafter.distributeAvailableFlags(countries, countryMapper, commonItems::ModFilesystem());
 
 	// do we have them yet?
 	const auto& flags = country->getFlags();
@@ -141,7 +141,7 @@ TEST(V3World_FlagNameLoaderTests, FlagsCanBeAssignedViaNameMatch)
 	countries.emplace("TAG", country);
 
 	// now assign flags.
-	flagCrafter.distributeAvailableFlags(countries, countryMapper);
+	flagCrafter.distributeAvailableFlags(countries, countryMapper, commonItems::ModFilesystem());
 
 	// do we have them yet?
 	const auto& flags = country->getFlags();
@@ -171,7 +171,7 @@ TEST(V3World_FlagNameLoaderTests, FlagsWithVanillaMatchesWillNotBeAssigned)
 	countries.emplace("ABC", country); // ABC has an override in vanilla flag definitions and will not be assigned a flag.
 
 	// now assign flags.
-	flagCrafter.distributeAvailableFlags(countries, countryMapper);
+	flagCrafter.distributeAvailableFlags(countries, countryMapper, commonItems::ModFilesystem());
 
 	// do we have them yet?
 	const auto& flags = country->getFlags();


### PR DESCRIPTION
- Instead of Vic3 defaults (which are often random) when no preset Vic3 CoA def available.