### PR TITLE
Mukhtay instead of Solon to Tungus

### DIFF
--- a/EU4ToVic3/Data_Files/configurables/colonial_cultures.txt
+++ b/EU4ToVic3/Data_Files/configurables/colonial_cultures.txt
@@ -56,6 +56,7 @@ link = { region = argentine_colony parent = portuguese name = "Cisplatinan" }
 ## Africa
 link = { region = africa_colony parent = ashkenazi name = "Camite" }
 link = { region = africa_colony parent = dutch name = "Boer" }
+link = { region = africa_colony parent = cosmopolitan_french name = "Pied-Noir" } # "Black-Feet", White colonists of French North Africa
 link = { region = africa_colony parent = chihan name = "Ruomu" } # Western counterpart of Fusang
 ## Caribbean
 link = { region = caribbean_colony parent = scottish name = "Rocabarraigh" }

--- a/EU4ToVic3/Data_Files/configurables/country_mappings.txt
+++ b/EU4ToVic3/Data_Files/configurables/country_mappings.txt
@@ -420,7 +420,7 @@ link = { eu4 = BAL name = "Baluchistan" vic3 = BLH } # Baluchistan
 link = { name = "Occitania" vic3 = OCC } # Occitania
 link = { eu4 = TUV name = "Tuva" vic3 = TUV } # Tuva
 link = { eu4 = COR name = "Corsica" vic3 = COR } # Corsica
-link = { eu4 = SOL vic3 = TNS } # Solon => Tungus
+link = { eu4 = MKT vic3 = TNS } # Mukhtuy => Tungus
 #link = { eu4 = ??? vic3 = FER } # Far East
 link = { name = "Tatarstan" vic3 = TAR } # Tatarstan => Tatarstan
 link = { eu4 = KZH name = "Kazakh" vic3 = KAZ } # Kazakhstan -> Kazakhstan

--- a/EU4ToVic3/Data_Files/configurables/excluded_trade_companies.txt
+++ b/EU4ToVic3/Data_Files/configurables/excluded_trade_companies.txt
@@ -1,5 +1,7 @@
 # Provinces from trade companies in these regions will not be split off into separate countries.
 # Africa should remain mostly directly-controlled.
+# Note that companies need to have 5+ provinces in a trade region before it splits off.
+# Companies with 4 or less provinces will not split off.
 
 excluded_trade_companies = {
 	trade_company_west_africa

--- a/EU4ToVic3/Data_Files/configurables/excluded_trade_companies.txt
+++ b/EU4ToVic3/Data_Files/configurables/excluded_trade_companies.txt
@@ -8,6 +8,7 @@ excluded_trade_companies = {
 	# trade_company_south_africa
 	trade_company_east_africa
 	trade_company_timbuktu
+	trade_company_safi
 	trade_company_tunis
 	trade_company_katsina
 	trade_company_ethiopia


### PR DESCRIPTION
- Remapped Mukhtay (MKT) to Tungus instead of Solon.