### PR TITLE
fix: update `law_map` configurable

### DIFF
--- a/EU4ToVic3/Data_Files/configurables/law_map.txt
+++ b/EU4ToVic3/Data_Files/configurables/law_map.txt
@@ -731,7 +731,7 @@ lawgroup_trade_policy = {
 		}
 	}
 	law_mercantilism = {
-		forms = { republic theocracy }
+		forms = { monarchy republic theocracy }
 		ideas = { indigenous_ideas maritime_ideas }
 		reforms = { enforce_trader_privileges_reform bengali_reform merchants_reform venice_merchants_reform 
 			open_naval_services_reform mission_to_kill_pirates_reform commercial_mission_reform
@@ -742,8 +742,8 @@ lawgroup_trade_policy = {
 		}
 	}
 	law_isolationism = {
-		forms = { monarchy tribal native }
-		ideas = { offensive_ideas }
+		forms = { tribal native }
+		ideas = { }
 		reforms = { pirate_republic_reform the_pirate_ways_reform war_against_the_world_doctrine_reform 
 			embedded_norse_government_reform war_economy_reform
 		}


### PR DESCRIPTION
### What
---
* Made it so that monarchies fallback to `law_mercantilism`
* removed `offensive_ideas` from counting towards isolationism

### Why
---
* Upon conversion, a staggering amount of monarchies are isolationist ( which looks odd given the trading meta of EU4). There is also balancing to consider, since due to how Vic3 law mechanics work, these countries will probably **stay** isolationist. The last statement is based on empirical evidence, so take it with a grain of salt.
* The `offensive_ideas` feel a bit odd to count towards isolationism as they are too generic for that. On the other hand, the reform already in place serve as a much more fitting alternative ( although I haven't looked at them in-depth, I just glanced at the names and remembered some EU4 descriptions )