### PR TITLE
Power bloc relations

### DIFF
--- a/EU4ToVic3/Data_Files/configurables/diplomatic_map.txt
+++ b/EU4ToVic3/Data_Files/configurables/diplomatic_map.txt
@@ -27,6 +27,10 @@ colony = { self_governing_colony colony viking_settlement annexable_colony europ
 
 chartered_company = { private_enterprise commercial_enterprise banking_family_subject dutch_commercial_enterprise }
 
+# Adds the subject to the overlord's power block without
+# creating any overlord relationship.
+power_bloc = { }
+
 # Double-sided agreements
 double_defensive_pact = { alliance }
 

--- a/EU4ToVic3/Source/Output/outDiplomacy/outDiplomacy.cpp
+++ b/EU4ToVic3/Source/Output/outDiplomacy/outDiplomacy.cpp
@@ -119,6 +119,8 @@ void OUT::exportPacts(const std::filesystem::path& outputName, const std::vector
 			continue;
 		else if (agreement.type == "rivalry") // VN-imported rivalries are agreements, not country-bound rivalries, so they end up here.
 			outAgreement(rivals, agreement);
+		else if (agreement.type == "power_bloc") // Not a Vicky treaty, used for bloc membership only.
+			continue;
 		else
 			outAgreement(subjects, agreement);
 	}

--- a/EU4ToVic3/Source/V3World/PoliticalManager/PoliticalManager.cpp
+++ b/EU4ToVic3/Source/V3World/PoliticalManager/PoliticalManager.cpp
@@ -644,7 +644,7 @@ void V3::PoliticalManager::createPowerBlocs()
 	std::map<std::string, std::set<std::string>> ownerSubjects;
 	std::map<std::string, std::set<std::string>> mergedOwnerSubjects;
 	std::map<std::string, std::string> subjectOwner;
-	std::set<std::string> subjectTypes = {"dominion", "protectorate", "tributary", "personal_union", "puppet", "vassal"};
+	std::set<std::string> subjectTypes = {"dominion", "protectorate", "tributary", "personal_union", "puppet", "vassal", "power_bloc"};
 	std::map<std::string, date> blocStartDates;
 
 	for (const auto& agreement: agreements)


### PR DESCRIPTION
Adds a `power_bloc` relationship; subject types added to this relationship will be added to the overlord's power bloc without creating any overlord/vassal treaty. 