### PR TITLE
Map Stettin to Stettin

### DIFF
--- a/EU4ToVic3/Data_Files/configurables/province_mappings.txt
+++ b/EU4ToVic3/Data_Files/configurables/province_mappings.txt
@@ -195,7 +195,7 @@
 	link = { eu4 = 1940 vic3 = xA2805F vic3 = x9D8087 vic3 = x11A021 vic3 = xCDD223 } # Belz -> STATE_EAST_GALICIA, STATE_EAST_GALICIA, Lviv [city], STATE_EAST_GALICIA
 	link = { eu4 = 4538 vic3 = x1A9FFE vic3 = xAFEBC8 } # Chelm -> STATE_VOLHYNIA, STATE_VOLHYNIA
 	link = { eu4 = 2969 vic3 = xB90BFF vic3 = xF77289 vic3 = x19AE19 } # Sternberg -> STATE_BRANDENBURG, STATE_BRANDENBURG, Schwedt [mine]
-	link = { eu4 = 49 vic3 = x3C26DD vic3 = x6A53CF vic3 = x514C51 } # Neumark -> STATE_POMERANIA, Stettin [city], Stargard [wood]
+	link = { eu4 = 49 vic3 = x3C26DD vic3 = x514C51 } # Neumark -> STATE_POMERANIA, Stargard [wood]
 	link = { eu4 = 4746 vic3 = xA9BD82 } # Stargard -> STATE_POMERANIA
 	link = { eu4 = 255 vic3 = x999CEE vic3 = x635336 vic3 = x41E0A0 } # Kalisz -> Posen [city], STATE_POSEN, STATE_POSEN
 	link = { eu4 = 2424 vic3 = xCAE5B0 vic3 = xE369C4 vic3 = x8F9F20 } # Peremyshl -> STATE_EAST_GALICIA, STATE_EAST_GALICIA, Stryi [wood]
@@ -346,7 +346,7 @@
 	link = { eu4 = 51 vic3 = x9E7304 vic3 = x61C0A0 } # Ruppin -> STATE_BRANDENBURG, STATE_BRANDENBURG
 	link = { eu4 = 4786 vic3 = x82F9A8 } # Prignitz -> STATE_BRANDENBURG
 	link = { eu4 = 4749 vic3 = x24CA48 vic3 = xE041A0 vic3 = xD9A469 } # Neubrandenburg -> STATE_MECKLENBURG, Neustrelitz [mine], Neubrandenburg [farm]
-	link = { eu4 = 1858 vic3 = xA04121 } # Stettin -> STATE_POMERANIA
+	link = { eu4 = 1858 vic3 = x6A53CF vic3 = xA04121 } # Stettin -> Stettin [city], STATE_POMERANIA
 	link = { eu4 = 2994 vic3 = xE1A03A } # Wolgast -> STATE_POMERANIA
 	link = { eu4 = 46 vic3 = x12E54F vic3 = xD8F441 vic3 = x4545BE } # Rostock -> G�strow [wood], Rostock [port], STATE_MECKLENBURG
 	link = { eu4 = 2996 vic3 = xE080A0 } # Wismar -> Schwerin [city]


### PR DESCRIPTION
Noticed after converting my PLC save that my continous Pomeranian coast got separated:
<img width="482" height="379" alt="obraz" src="https://github.com/user-attachments/assets/7551ec73-dacb-464b-8e9f-44a03e143585" />

This change fixes the city not being mapped to its equivalent. Also changes from 1->1 and 1->3 mappings to more balanced two 1->2 mappings.

Before:
<img width="1899" height="626" alt="obraz" src="https://github.com/user-attachments/assets/74d1d4b1-8bb3-485c-b09b-c33433d35b8c" />
<img width="1895" height="541" alt="obraz" src="https://github.com/user-attachments/assets/788df813-3cd8-42ba-8776-f9ff9d121b8f" />

After:
<img width="1896" height="561" alt="obraz" src="https://github.com/user-attachments/assets/3ad45559-1997-4eea-b779-6b8f27455dac" />
<img width="1896" height="565" alt="obraz" src="https://github.com/user-attachments/assets/ad682a41-1072-4e26-96cd-9015559c6c17" />
