### PR TITLE
Prevent anachronistic country flavor text in the lobby

### DIFF
--- a/EU4ToVic3/Source/Output/outLocalizations/outLocalizations.cpp
+++ b/EU4ToVic3/Source/Output/outLocalizations/outLocalizations.cpp
@@ -25,7 +25,7 @@ void OUT::exportPowerBlocLocs(const std::filesystem::path& outputName, const std
 	}
 }
 
-void OUT::exportCountryNamesAndAdjectives(const std::filesystem::path& outputName,
+void OUT::exportCountryNamesAdjectivesAndFlavor(const std::filesystem::path& outputName,
 	 const std::map<std::string, std::shared_ptr<V3::Country>>& countries,
 	 const V3::LocalizationLoader& knownLocs)
 {
@@ -41,10 +41,13 @@ void OUT::exportCountryNamesAndAdjectives(const std::filesystem::path& outputNam
 		output << commonItems::utf8BOM << "l_" << language << ":\n";
 		for (const auto& country: countries | std::views::values)
 		{
-			if (!knownLocs.getLocMapForKey(country->getTag()))
-				output << " " << country->getTag() << ": \"" << country->getName(language) << "\"\n";
-			if (!knownLocs.getLocMapForKey(country->getTag() + "_ADJ"))
-				output << " " << country->getTag() << "_ADJ: \"" << country->getAdjective(language) << "\"\n";
+			const auto& tag = country->getTag();
+			if (!knownLocs.getLocMapForKey(tag))
+				output << " " << tag << ": \"" << country->getName(language) << "\"\n";
+			if (!knownLocs.getLocMapForKey(tag + "_ADJ"))
+				output << " " << tag << "_ADJ: \"" << country->getAdjective(language) << "\"\n";
+			// Always overwrite flavor to avoid anachronistic loc.
+			output << " " << tag << "_FLAVOR_TEXT: \"$GENERIC_FLAVOR_TEXT$\"\n";
 		}
 		output.close();
 	}

--- a/EU4ToVic3/Source/Output/outLocalizations/outLocalizations.h
+++ b/EU4ToVic3/Source/Output/outLocalizations/outLocalizations.h
@@ -7,7 +7,7 @@
 
 namespace OUT
 {
-void exportCountryNamesAndAdjectives(const std::filesystem::path& outputName,
+void exportCountryNamesAdjectivesAndFlavor(const std::filesystem::path& outputName,
 	 const std::map<std::string, std::shared_ptr<V3::Country>>& countries,
 	 const V3::LocalizationLoader& knownLocs);
 void exportReligionLocs(const std::filesystem::path& outputName,

--- a/EU4ToVic3/Source/Output/outWorld.cpp
+++ b/EU4ToVic3/Source/Output/outWorld.cpp
@@ -102,7 +102,7 @@ void OUT::exportWorld(const Configuration& configuration, const V3::World& world
 	Log(LogLevel::Progress) << "90 %";
 
 	Log(LogLevel::Info) << "<- Writing Localizations";
-	exportCountryNamesAndAdjectives(outputName, world.getPoliticalManager().getCountries(), knownLocs);
+	exportCountryNamesAdjectivesAndFlavor(outputName, world.getPoliticalManager().getCountries(), knownLocs);
 	exportReligionLocs(outputName, world.getReligionMapper().getV3ReligionDefinitions(), knownLocs);
 	exportCultureLocs(outputName, world.getCultureMapper().getV3CultureDefinitions(), knownLocs);
 	exportCharacterLocs(outputName, world.getPoliticalManager().getCountries(), knownLocs);


### PR DESCRIPTION
Before:
<img width="404" height="804" alt="Britain flavor text" src="https://github.com/user-attachments/assets/d20fed34-550e-482a-8ff7-99acda2504f4" />


After:
<img width="406" height="675" alt="obraz" src="https://github.com/user-attachments/assets/88a277e4-d4c1-44d6-b10c-448dc721facd" />
