### PR TITLE
Fix "should be in utf8-bom encoding" errors from error.log

### DIFF
--- a/EU4ToVic3/Data_Files/blankMod/output/common/ideologies/zzz_converter_ideologies_overwrite.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/ideologies/zzz_converter_ideologies_overwrite.txt
@@ -1,4 +1,4 @@
-INJECT:ideology_traditionalist = {
+﻿INJECT:ideology_traditionalist = {
 	interest_group_leader_weight = {
 		#More likely for armed forces in a holy order (before secularization)
 		if = {

--- a/EU4ToVic3/Data_Files/blankMod/output/common/journal_entries/zzz_converter_confederation_je.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/journal_entries/zzz_converter_confederation_je.txt
@@ -1,4 +1,4 @@
-REPLACE:je_canada_can = {
+﻿REPLACE:je_canada_can = {
 	icon = "gfx/interface/icons/event_icons/waving_flag.dds"
 
 	group = je_group_historical_content

--- a/EU4ToVic3/Data_Files/blankMod/output/common/on_actions/zzz_immortal_on_actions.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/on_actions/zzz_immortal_on_actions.txt
@@ -1,4 +1,4 @@
-# Root = Character
+﻿# Root = Character
 on_character_death = {
 	on_actions = {
 		converter_dead_immortal_on_actions

--- a/EU4ToVic3/Data_Files/blankMod/output/common/script_values/zzz_matriarchy_values.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/script_values/zzz_matriarchy_values.txt
@@ -1,4 +1,4 @@
-# ig_female_general_chance
+﻿# ig_female_general_chance
 # ig_female_politician_chance_conversative
 # ig_female_politician_chance_moderate
 # ig_female_politician_chance_liberal

--- a/EU4ToVic3/Data_Files/blankMod/output/common/scripted_buttons/zzz_converter_formation_buttons.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/scripted_buttons/zzz_converter_formation_buttons.txt
@@ -1,4 +1,4 @@
-### Confederations of Subjects
+﻿### Confederations of Subjects
 REPLACE:je_canada_unite_can_button = {
 	name = "je_canada_unite_can_button"
 	desc = "je_canada_unite_can_button_desc"

--- a/EU4ToVic3/Data_Files/blankMod/output/common/scripted_effects/zzz_converter_effects_cultural.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/scripted_effects/zzz_converter_effects_cultural.txt
@@ -1,4 +1,4 @@
-# converter_historical_leader_cultures_effect
+﻿# converter_historical_leader_cultures_effect
 # converter_colonial_confederation_cultures_effect
 # converter_other_starting_cultural_effects
 # converter_cultural_traditions_effect

--- a/EU4ToVic3/Data_Files/blankMod/output/common/scripted_effects/zzz_converter_effects_gender.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/scripted_effects/zzz_converter_effects_gender.txt
@@ -1,4 +1,4 @@
-# converter_ig_devout_feminism_matriarchy_effect
+﻿# converter_ig_devout_feminism_matriarchy_effect
 # converter_ig_landowners_feminism_matriarchy_effect
 # converter_rule_63_effect
 

--- a/EU4ToVic3/Data_Files/blankMod/output/common/scripted_effects/zzz_converter_effects_new.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/scripted_effects/zzz_converter_effects_new.txt
@@ -1,4 +1,4 @@
-# converter_caudillismo_ideology_effect
+﻿# converter_caudillismo_ideology_effect
 # converter_pious_landowner_ideology_effect
 # converter_jeffersonian_ideology_effect
 # converter_russian_patriarch_ideology_effect

--- a/EU4ToVic3/Data_Files/blankMod/output/common/scripted_triggers/zzz_matriarchy_triggers.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/scripted_triggers/zzz_matriarchy_triggers.txt
@@ -1,4 +1,4 @@
-# is_matriarchal_country
+﻿# is_matriarchal_country
 # is_matriarchal_pop
 # is_feminist_country
 # is_feminist_pop

--- a/EU4ToVic3/Data_Files/blankMod/output/events/!00_converter_general_events_overwrite.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/events/!00_converter_general_events_overwrite.txt
@@ -1,4 +1,4 @@
-namespace = commander_events
+﻿namespace = commander_events
 namespace = communism
 namespace = crime_events
 namespace = german_unification

--- a/EU4ToVic3/Data_Files/blankMod/output/events/agitators_events/!00_converter_agitators_events_overwrite.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/events/agitators_events/!00_converter_agitators_events_overwrite.txt
@@ -1,4 +1,4 @@
-namespace = dreyfus
+﻿namespace = dreyfus
 namespace = paris_commune_pulse_events
 
 # Dreyfus conviction event

--- a/EU4ToVic3/Data_Files/blankMod/output/events/agitators_events/historic_agitator_events.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/events/agitators_events/historic_agitator_events.txt
@@ -1,4 +1,4 @@
-namespace = historical_agitators
+﻿namespace = historical_agitators
 
 #cooldowns handled by variables
 historical_agitators.1 = { #Vladimir Lenin

--- a/EU4ToVic3/Data_Files/blankMod/output/events/brazil/!00_converter_brazil_overwrite.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/events/brazil/!00_converter_brazil_overwrite.txt
@@ -1,4 +1,4 @@
-namespace = positivism
+﻿namespace = positivism
 
 positivism.1 = {
 	type = country_event

--- a/EU4ToVic3/Data_Files/blankMod/output/events/canada_australia_events.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/events/canada_australia_events.txt
@@ -1,4 +1,4 @@
-namespace = can_aus
+﻿namespace = can_aus
 
 # Canadian colony absorbs a poorer neighbor
 can_aus.1 = {

--- a/EU4ToVic3/Data_Files/blankMod/output/events/suffragist_events.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/events/suffragist_events.txt
@@ -1,4 +1,4 @@
-namespace = suffragist_events
+﻿namespace = suffragist_events
 
 # Suffragist Protest
 suffragist_events.1 = {


### PR DESCRIPTION
Example:

> [11:24:10][lexer.cpp:285]: File 'common/script_values/zzz_matriarchy_values.txt' should be in utf8-bom encoding (will try to use it anyways)