### PR TITLE
Fix CultureDefinitionLoader not recognizing inject/replace keywords

### DIFF
--- a/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.cpp
+++ b/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.cpp
@@ -39,7 +39,22 @@ void mappers::CultureDefinitionLoader::loadDefinitions(std::istream& theStream)
 
 void mappers::CultureDefinitionLoader::registerKeys()
 {
-	registerRegex(commonItems::catchallRegex, [this](const std::string& cultureName, std::istream& theStream) {
+	static const std::vector<std::string> injectReplaceKeywords = {
+		"INJECT:", "REPLACE:", "TRY_INJECT:", "TRY_REPLACE:", "INJECT_OR_CREATE:", "REPLACE_OR_CREATE:"
+	};
+
+	registerRegex(commonItems::catchallRegex, [this](const std::string& cultureNameStr, std::istream& theStream) {
+		// If cultureName starts with any of the inject/replace keywords, strip them.
+		std::string cultureName = cultureNameStr;
+		for (const auto& keyword: injectReplaceKeywords)
+		{
+			if (cultureName.starts_with(keyword))
+			{
+				cultureName = cultureName.substr(keyword.size());
+				break;
+			}
+		}
+
 		auto relDef = CultureDefinitionEntry(theStream, skipProcessing, skipExport).getCultureDef();
 		relDef.name = cultureName;
 

--- a/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.cpp
+++ b/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.cpp
@@ -39,9 +39,8 @@ void mappers::CultureDefinitionLoader::loadDefinitions(std::istream& theStream)
 
 void mappers::CultureDefinitionLoader::registerKeys()
 {
-	static const std::vector<std::string> injectReplaceKeywords = {
-		"INJECT:", "REPLACE:", "TRY_INJECT:", "TRY_REPLACE:", "INJECT_OR_CREATE:", "REPLACE_OR_CREATE:"
-	};
+	static const std::vector<std::string> injectReplaceKeywords =
+		 {"INJECT:", "REPLACE:", "TRY_INJECT:", "TRY_REPLACE:", "INJECT_OR_CREATE:", "REPLACE_OR_CREATE:"};
 
 	registerRegex(commonItems::catchallRegex, [this](const std::string& cultureNameStr, std::istream& theStream) {
 		// If cultureName starts with any of the inject/replace keywords, strip them.


### PR DESCRIPTION
Before the fix, the outputted `common\static_modifiers\99_converted_cultures_static_modifiers.txt` file contained entries like `REPLACE_OR_CREATE:INJECT:gondi_standard_of_living_modifier_positive`.
Now it's just `REPLACE_OR_CREATE:gondi_standard_of_living_modifier_positive`.