### PR TITLE
Actual INJECT/REPLACE logic for culture definitions loader

### DIFF
--- a/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDef.h
+++ b/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDef.h
@@ -1,16 +1,36 @@
 #ifndef CULTURE_DEF_H
 #define CULTURE_DEF_H
 #include "Color.h"
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
 
 namespace mappers
 {
+enum class CultureDefinitionOperation
+{
+	Assign,
+	Inject,
+	Replace,
+	TryInject,
+	TryReplace,
+	InjectOrCreate,
+	ReplaceOrCreate
+};
+
 struct CultureDef
 {
+	CultureDefinitionOperation operation = CultureDefinitionOperation::Assign;
 	std::string name;
 	std::optional<commonItems::Color> color;
+	bool hasColor = false;
 	std::string religion;
+	bool hasReligion = false;
 	std::string language;
+	bool hasLanguage = false;
 	std::string heritage;
+	bool hasHeritage = false;
 	std::set<std::string> obsessions;
 	std::set<std::string> traditions;
 	std::set<std::string> maleCommonFirstNames;
@@ -22,6 +42,7 @@ struct CultureDef
 	std::set<std::string> regalLastNames;
 	std::set<std::string> ethnicities;
 	std::string graphics;
+	bool hasGraphics = false;
 	bool skipProcessing = false; // We're skipping *separate* processing for defs that we import (from DW for example).
 	bool skipExport = false;	  // We're skipping *separate* export for defs that we copy over from blankmod.
 

--- a/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionEntry.cpp
+++ b/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionEntry.cpp
@@ -32,15 +32,19 @@ void mappers::CultureDefinitionEntry::registerkeys()
 	ethStripper.registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
 
 	registerKeyword("color", [this](std::istream& theStream) {
+		cultureDef.hasColor = true;
 		cultureDef.color = commonItems::Color::Factory().getColor(theStream);
 	});
 	registerKeyword("religion", [this](std::istream& theStream) {
+		cultureDef.hasReligion = true;
 		cultureDef.religion = commonItems::getString(theStream);
 	});
 	registerKeyword("language", [this](std::istream& theStream) {
+		cultureDef.hasLanguage = true;
 		cultureDef.language = commonItems::getString(theStream);
 	});
 	registerKeyword("heritage", [this](std::istream& theStream) {
+		cultureDef.hasHeritage = true;
 		cultureDef.heritage = commonItems::getString(theStream);
 	});
 	registerKeyword("traditions", [this](std::istream& theStream) {
@@ -146,6 +150,7 @@ void mappers::CultureDefinitionEntry::registerkeys()
 		ethStripper.parseStream(theStream);
 	});
 	registerKeyword("graphics", [this](std::istream& theStream) {
+		cultureDef.hasGraphics = true;
 		cultureDef.graphics = commonItems::getString(theStream);
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);

--- a/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.cpp
+++ b/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.cpp
@@ -4,6 +4,153 @@
 #include "CultureDefinitionEntry.h"
 #include "Log.h"
 #include "ParserHelpers.h"
+#include <array>
+#include <string_view>
+
+namespace
+{
+using Operation = mappers::CultureDefinitionOperation;
+
+constexpr std::array<std::pair<std::string_view, Operation>, 6> operationPrefixes{{
+	 {"INJECT:", Operation::Inject},
+	 {"REPLACE:", Operation::Replace},
+	 {"TRY_INJECT:", Operation::TryInject},
+	 {"TRY_REPLACE:", Operation::TryReplace},
+	 {"INJECT_OR_CREATE:", Operation::InjectOrCreate},
+	 {"REPLACE_OR_CREATE:", Operation::ReplaceOrCreate},
+}};
+
+std::pair<Operation, std::string> determineOperationAndName(const std::string& cultureNameStr)
+{
+	for (const auto& [prefix, operation]: operationPrefixes)
+	{
+		if (cultureNameStr.rfind(prefix.data(), 0) == 0)
+			return {operation, cultureNameStr.substr(prefix.size())};
+	}
+
+	return {Operation::Assign, cultureNameStr};
+}
+
+const char* toString(const Operation operation)
+{
+	switch (operation)
+	{
+		case Operation::Assign:
+			return "assignment";
+		case Operation::Inject:
+			return "INJECT";
+		case Operation::Replace:
+			return "REPLACE";
+		case Operation::TryInject:
+			return "TRY_INJECT";
+		case Operation::TryReplace:
+			return "TRY_REPLACE";
+		case Operation::InjectOrCreate:
+			return "INJECT_OR_CREATE";
+		case Operation::ReplaceOrCreate:
+			return "REPLACE_OR_CREATE";
+	}
+
+	return "unknown operation";
+}
+
+void mergeLocalizations(std::map<std::string, std::string>& target, const std::map<std::string, std::string>& source)
+{
+	for (const auto& [key, value]: source)
+		target.insert_or_assign(key, value);
+}
+
+void injectCultureDefinition(mappers::CultureDef& target, const mappers::CultureDef& source)
+{
+	if (source.hasColor)
+		target.color = source.color;
+	if (source.hasReligion)
+		target.religion = source.religion;
+	if (source.hasLanguage)
+		target.language = source.language;
+	if (source.hasHeritage)
+		target.heritage = source.heritage;
+	if (source.hasGraphics)
+		target.graphics = source.graphics;
+
+	target.obsessions.insert(source.obsessions.begin(), source.obsessions.end());
+	target.traditions.insert(source.traditions.begin(), source.traditions.end());
+	target.maleCommonFirstNames.insert(source.maleCommonFirstNames.begin(), source.maleCommonFirstNames.end());
+	target.femaleCommonFirstNames.insert(source.femaleCommonFirstNames.begin(), source.femaleCommonFirstNames.end());
+	target.commonLastNames.insert(source.commonLastNames.begin(), source.commonLastNames.end());
+	target.nobleLastNames.insert(source.nobleLastNames.begin(), source.nobleLastNames.end());
+	target.maleRegalFirstNames.insert(source.maleRegalFirstNames.begin(), source.maleRegalFirstNames.end());
+	target.femaleRegalFirstNames.insert(source.femaleRegalFirstNames.begin(), source.femaleRegalFirstNames.end());
+	target.regalLastNames.insert(source.regalLastNames.begin(), source.regalLastNames.end());
+	target.ethnicities.insert(source.ethnicities.begin(), source.ethnicities.end());
+
+	target.skipProcessing = source.skipProcessing;
+	target.skipExport = source.skipExport;
+	mergeLocalizations(target.locBlock, source.locBlock);
+	mergeLocalizations(target.nameLocBlock, source.nameLocBlock);
+	target.operation = Operation::Assign;
+}
+
+void materializeCultureDefinition(mappers::CultureDef& cultureDefinition)
+{
+	cultureDefinition.operation = Operation::Assign;
+}
+} // namespace
+
+void mappers::CultureDefinitionLoader::applyDefinition(CultureDef cultureDefinition)
+{
+	const auto cultureName = cultureDefinition.name;
+	const auto operation = cultureDefinition.operation;
+	auto existingDefinition = cultureDefinitions.find(cultureName);
+
+	switch (operation)
+	{
+		case Operation::Assign:
+		case Operation::ReplaceOrCreate:
+			materializeCultureDefinition(cultureDefinition);
+			cultureDefinitions.insert_or_assign(cultureName, std::move(cultureDefinition));
+			return;
+		case Operation::InjectOrCreate:
+			if (existingDefinition == cultureDefinitions.end())
+			{
+				materializeCultureDefinition(cultureDefinition);
+				cultureDefinitions.emplace(cultureName, std::move(cultureDefinition));
+			}
+			else
+			{
+				injectCultureDefinition(existingDefinition->second, cultureDefinition);
+			}
+			return;
+		case Operation::Inject:
+			if (existingDefinition == cultureDefinitions.end())
+			{
+				Log(LogLevel::Warning) << toString(operation) << " requested for missing culture definition " << cultureName << ".";
+				return;
+			}
+			injectCultureDefinition(existingDefinition->second, cultureDefinition);
+			return;
+		case Operation::TryInject:
+			if (existingDefinition != cultureDefinitions.end())
+				injectCultureDefinition(existingDefinition->second, cultureDefinition);
+			return;
+		case Operation::Replace:
+			if (existingDefinition == cultureDefinitions.end())
+			{
+				Log(LogLevel::Warning) << toString(operation) << " requested for missing culture definition " << cultureName << ".";
+				return;
+			}
+			materializeCultureDefinition(cultureDefinition);
+			existingDefinition->second = std::move(cultureDefinition);
+			return;
+		case Operation::TryReplace:
+			if (existingDefinition != cultureDefinitions.end())
+			{
+				materializeCultureDefinition(cultureDefinition);
+				existingDefinition->second = std::move(cultureDefinition);
+			}
+			return;
+	}
+}
 
 void mappers::CultureDefinitionLoader::loadDefinitions(const commonItems::ModFilesystem& modFS)
 {
@@ -39,28 +186,12 @@ void mappers::CultureDefinitionLoader::loadDefinitions(std::istream& theStream)
 
 void mappers::CultureDefinitionLoader::registerKeys()
 {
-	static const std::vector<std::string> injectReplaceKeywords =
-		 {"INJECT:", "REPLACE:", "TRY_INJECT:", "TRY_REPLACE:", "INJECT_OR_CREATE:", "REPLACE_OR_CREATE:"};
-
 	registerRegex(commonItems::catchallRegex, [this](const std::string& cultureNameStr, std::istream& theStream) {
-		// If cultureName starts with any of the inject/replace keywords, strip them.
-		std::string cultureName = cultureNameStr;
-		for (const auto& keyword: injectReplaceKeywords)
-		{
-			if (cultureName.starts_with(keyword))
-			{
-				cultureName = cultureName.substr(keyword.size());
-				break;
-			}
-		}
-
+		const auto [operation, cultureName] = determineOperationAndName(cultureNameStr);
 		auto relDef = CultureDefinitionEntry(theStream, skipProcessing, skipExport).getCultureDef();
+		relDef.operation = operation;
 		relDef.name = cultureName;
-
-		if (!cultureDefinitions.contains(cultureName))
-			cultureDefinitions.emplace(cultureName, relDef);
-		else
-			cultureDefinitions.at(cultureName) = relDef;
+		applyDefinition(std::move(relDef));
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
 }

--- a/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.h
+++ b/EU4ToVic3/Source/Mappers/CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.h
@@ -16,6 +16,7 @@ class CultureDefinitionLoader: commonItems::parser
 	[[nodiscard]] const auto& getDefinitions() const { return cultureDefinitions; }
 
   private:
+	void applyDefinition(CultureDef cultureDefinition);
 	void registerKeys();
 
 	std::map<std::string, CultureDef> cultureDefinitions;

--- a/EU4ToVic3Tests/MapperTests/CultureMapperTests/CultureDefinitionLoaderTests/CultureDefinitionLoaderTests.cpp
+++ b/EU4ToVic3Tests/MapperTests/CultureMapperTests/CultureDefinitionLoaderTests/CultureDefinitionLoaderTests.cpp
@@ -12,7 +12,7 @@ void loadDefinition(mappers::CultureDefinitionLoader& loader, const std::string&
 	std::stringstream input(definition);
 	loader.loadDefinitions(input);
 }
-}
+} // namespace
 
 TEST(Mappers_CultureDefinitionLoaderTests, LoaderDefaultsToDry)
 {

--- a/EU4ToVic3Tests/MapperTests/CultureMapperTests/CultureDefinitionLoaderTests/CultureDefinitionLoaderTests.cpp
+++ b/EU4ToVic3Tests/MapperTests/CultureMapperTests/CultureDefinitionLoaderTests/CultureDefinitionLoaderTests.cpp
@@ -1,10 +1,17 @@
 #include "CultureMapper/CultureDefinitionLoader/CultureDefinitionLoader.h"
 #include "gtest/gtest.h"
 #include <gmock/gmock-matchers.h>
+#include <sstream>
 
 namespace
 {
 const auto modFS = commonItems::ModFilesystem("TestFiles/vic3installation/game", {});
+
+void loadDefinition(mappers::CultureDefinitionLoader& loader, const std::string& definition)
+{
+	std::stringstream input(definition);
+	loader.loadDefinitions(input);
+}
 }
 
 TEST(Mappers_CultureDefinitionLoaderTests, LoaderDefaultsToDry)
@@ -23,4 +30,208 @@ TEST(Mappers_CultureDefinitionLoaderTests, CulturesCanBeRetrieved)
 
 	EXPECT_EQ("vculture2", vculture2.name);
 	EXPECT_THAT(vculture2.ethnicities, testing::UnorderedElementsAre("ethnotest2"));
+}
+
+TEST(Mappers_CultureDefinitionLoaderTests, InjectMergesIntoExistingCulture)
+{
+	mappers::CultureDefinitionLoader loader;
+	loadDefinition(loader,
+		 R"(gondi = {
+			religion = religion_base
+			heritage = heritage_base
+			language = language_base
+			traditions = { tradition_base }
+			male_common_first_names = { base_name }
+			ethnicities = { 1 = ethnicity_base }
+			graphics = graphics_base
+		})");
+	loadDefinition(loader,
+		 R"(INJECT:gondi = {
+			religion = religion_injected
+			traditions = { tradition_injected }
+			male_common_first_names = { injected_name }
+			ethnicities = { 1 = ethnicity_injected }
+		})");
+
+	const auto& gondi = loader.getDefinitions().at("gondi");
+	EXPECT_EQ("religion_injected", gondi.religion);
+	EXPECT_EQ("heritage_base", gondi.heritage);
+	EXPECT_EQ("language_base", gondi.language);
+	EXPECT_EQ("graphics_base", gondi.graphics);
+	EXPECT_THAT(gondi.traditions, testing::UnorderedElementsAre("tradition_base", "tradition_injected"));
+	EXPECT_THAT(gondi.maleCommonFirstNames, testing::UnorderedElementsAre("base_name", "injected_name"));
+	EXPECT_THAT(gondi.ethnicities, testing::UnorderedElementsAre("ethnicity_base", "ethnicity_injected"));
+}
+
+TEST(Mappers_CultureDefinitionLoaderTests, ReplaceOverwritesExistingCulture)
+{
+	mappers::CultureDefinitionLoader loader;
+	loadDefinition(loader,
+		 R"(gondi = {
+			religion = religion_base
+			heritage = heritage_base
+			traditions = { tradition_base }
+			male_common_first_names = { base_name }
+			graphics = graphics_base
+		})");
+	loadDefinition(loader,
+		 R"(REPLACE:gondi = {
+			religion = religion_replaced
+			graphics = graphics_replaced
+		})");
+
+	const auto& gondi = loader.getDefinitions().at("gondi");
+	EXPECT_EQ("religion_replaced", gondi.religion);
+	EXPECT_TRUE(gondi.heritage.empty());
+	EXPECT_TRUE(gondi.traditions.empty());
+	EXPECT_TRUE(gondi.maleCommonFirstNames.empty());
+	EXPECT_EQ("graphics_replaced", gondi.graphics);
+}
+
+TEST(Mappers_CultureDefinitionLoaderTests, TryInjectMergesIntoExistingCulture)
+{
+	mappers::CultureDefinitionLoader loader;
+	loadDefinition(loader,
+		 R"(gondi = {
+			language = language_base
+			common_last_names = { base_last_name }
+		})");
+	loadDefinition(loader,
+		 R"(TRY_INJECT:gondi = {
+			language = language_injected
+			common_last_names = { injected_last_name }
+		})");
+
+	const auto& gondi = loader.getDefinitions().at("gondi");
+	EXPECT_EQ("language_injected", gondi.language);
+	EXPECT_THAT(gondi.commonLastNames, testing::UnorderedElementsAre("base_last_name", "injected_last_name"));
+}
+
+TEST(Mappers_CultureDefinitionLoaderTests, TryReplaceOverwritesExistingCulture)
+{
+	mappers::CultureDefinitionLoader loader;
+	loadDefinition(loader,
+		 R"(gondi = {
+			heritage = heritage_base
+			female_common_first_names = { base_name }
+		})");
+	loadDefinition(loader,
+		 R"(TRY_REPLACE:gondi = {
+			heritage = heritage_replaced
+		})");
+
+	const auto& gondi = loader.getDefinitions().at("gondi");
+	EXPECT_EQ("heritage_replaced", gondi.heritage);
+	EXPECT_TRUE(gondi.femaleCommonFirstNames.empty());
+}
+
+TEST(Mappers_CultureDefinitionLoaderTests, InjectOnMissingCultureDoesNotCreateEntry)
+{
+	mappers::CultureDefinitionLoader loader;
+	loadDefinition(loader,
+		 R"(INJECT:missing_culture = {
+			religion = religion_injected
+		})");
+
+	EXPECT_FALSE(loader.getDefinitions().contains("missing_culture"));
+}
+
+TEST(Mappers_CultureDefinitionLoaderTests, ReplaceOnMissingCultureDoesNotCreateEntry)
+{
+	mappers::CultureDefinitionLoader loader;
+	loadDefinition(loader,
+		 R"(REPLACE:missing_culture = {
+			religion = religion_replaced
+		})");
+
+	EXPECT_FALSE(loader.getDefinitions().contains("missing_culture"));
+}
+
+TEST(Mappers_CultureDefinitionLoaderTests, TryInjectOnMissingCultureDoesNotCreateEntry)
+{
+	mappers::CultureDefinitionLoader loader;
+	loadDefinition(loader,
+		 R"(TRY_INJECT:missing_culture = {
+			religion = religion_injected
+		})");
+
+	EXPECT_FALSE(loader.getDefinitions().contains("missing_culture"));
+}
+
+TEST(Mappers_CultureDefinitionLoaderTests, TryReplaceOnMissingCultureDoesNotCreateEntry)
+{
+	mappers::CultureDefinitionLoader loader;
+	loadDefinition(loader,
+		 R"(TRY_REPLACE:missing_culture = {
+			religion = religion_replaced
+		})");
+
+	EXPECT_FALSE(loader.getDefinitions().contains("missing_culture"));
+}
+
+TEST(Mappers_CultureDefinitionLoaderTests, InjectOrCreateInjectsIntoExistingCulture)
+{
+	mappers::CultureDefinitionLoader loader;
+	loadDefinition(loader,
+		 R"(gondi = {
+			religion = religion_base
+			noble_last_names = { base_name }
+		})");
+	loadDefinition(loader,
+		 R"(INJECT_OR_CREATE:gondi = {
+			religion = religion_injected
+			noble_last_names = { injected_name }
+		})");
+
+	const auto& gondi = loader.getDefinitions().at("gondi");
+	EXPECT_EQ("religion_injected", gondi.religion);
+	EXPECT_THAT(gondi.nobleLastNames, testing::UnorderedElementsAre("base_name", "injected_name"));
+}
+
+TEST(Mappers_CultureDefinitionLoaderTests, InjectOrCreateCreatesMissingCulture)
+{
+	mappers::CultureDefinitionLoader loader;
+	loadDefinition(loader,
+		 R"(INJECT_OR_CREATE:new_culture = {
+			religion = religion_created
+			traditions = { created_tradition }
+		})");
+
+	ASSERT_TRUE(loader.getDefinitions().contains("new_culture"));
+	const auto& newCulture = loader.getDefinitions().at("new_culture");
+	EXPECT_EQ("religion_created", newCulture.religion);
+	EXPECT_THAT(newCulture.traditions, testing::UnorderedElementsAre("created_tradition"));
+}
+
+TEST(Mappers_CultureDefinitionLoaderTests, ReplaceOrCreateReplacesExistingCulture)
+{
+	mappers::CultureDefinitionLoader loader;
+	loadDefinition(loader,
+		 R"(gondi = {
+			religion = religion_base
+			regal_last_names = { base_name }
+		})");
+	loadDefinition(loader,
+		 R"(REPLACE_OR_CREATE:gondi = {
+			religion = religion_replaced
+		})");
+
+	const auto& gondi = loader.getDefinitions().at("gondi");
+	EXPECT_EQ("religion_replaced", gondi.religion);
+	EXPECT_TRUE(gondi.regalLastNames.empty());
+}
+
+TEST(Mappers_CultureDefinitionLoaderTests, ReplaceOrCreateCreatesMissingCulture)
+{
+	mappers::CultureDefinitionLoader loader;
+	loadDefinition(loader,
+		 R"(REPLACE_OR_CREATE:new_culture = {
+			heritage = heritage_created
+			female_regal_first_names = { created_name }
+		})");
+
+	ASSERT_TRUE(loader.getDefinitions().contains("new_culture"));
+	const auto& newCulture = loader.getDefinitions().at("new_culture");
+	EXPECT_EQ("heritage_created", newCulture.heritage);
+	EXPECT_THAT(newCulture.femaleRegalFirstNames, testing::UnorderedElementsAre("created_name"));
 }


### PR DESCRIPTION
My previous CultureDefinitionLoader change just stripped the INJECT/REPLACE keywords from culture definition keys, but I realized this isn't enough, because an INJECT definition would fully replace a complete definition, leading to problems like:

> 2026-05-24 15:47:21  [WARNING] Culture gondi has no westernization.txt traits linked!

So now it should actually work according to the Wiki: https://vic3.paradoxwikis.com/Mod_compatibility#Inject_and_replace.

Now the westernization warnings are gone.