### PR TITLE
Fix missing `white_dark` color definition

### DIFF
--- a/EU4ToVic3/Data_Files/blankMod/output/common/named_colors/converter_coa_colors.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/named_colors/converter_coa_colors.txt
@@ -1,0 +1,3 @@
+colors = {
+    white_dark = hsv360 { 20 0 75 }
+}


### PR DESCRIPTION
It was causing errors for 2 CoAs from 99_legacy.txt.