### PR TITLE
Fix for missing tradition_feminist and tradition_egalitarian

### DIFF
--- a/EU4ToVic3/Data_Files/blankMod/output/common/discrimination_traits/zzz_converter_cultural_traditions.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/discrimination_traits/zzz_converter_cultural_traditions.txt
@@ -10,3 +10,6 @@ REPLACE_OR_CREATE:tradition_matriarchal = {
 REPLACE_OR_CREATE:tradition_feminist = {
 	type = tradition
 }
+REPLACE_OR_CREATE:tradition_egalitarian = {
+	type = tradition
+}

--- a/EU4ToVic3/Data_Files/blankMod/output/common/discrimination_traits/zzz_converter_cultural_traditions.txt
+++ b/EU4ToVic3/Data_Files/blankMod/output/common/discrimination_traits/zzz_converter_cultural_traditions.txt
@@ -7,6 +7,6 @@ REPLACE_OR_CREATE:tradition_vivaparity = {
 REPLACE_OR_CREATE:tradition_matriarchal = {
 	type = tradition
 }
-REPLACE_OR_CREATE:tradition_matriarchal = {
-	type = feminist
+REPLACE_OR_CREATE:tradition_feminist = {
+	type = tradition
 }

--- a/EU4ToVic3/Data_Files/blankMod/output/localization/english/replace/zzz_converter_traits_traditions_l_english.yml
+++ b/EU4ToVic3/Data_Files/blankMod/output/localization/english/replace/zzz_converter_traits_traditions_l_english.yml
@@ -3,3 +3,4 @@
  tradition_vivaparity:0 "Vivaparity"
  tradition_matriarchal:0 "Matriarchal"
  tradition_feminist:0 "Feminist"
+ tradition_egalitarian:0 "Egalitarian"


### PR DESCRIPTION
Fixes the following vic3-tiger errors:
```
error(choice): expected one of heritage, language, tradition
  --> [MOD] common\discrimination_traits\zzz_converter_cultural_traditions.txt
11 |     type = feminist
   |            ^^^^^^^^

error(missing-item): discrimination trait tradition_feminist not defined in common/discrimination_traits/
  --> [MOD] common\scripted_effects\zzz_converter_effects_gender.txt
18 |                 has_discrimination_trait = tradition_feminist
   |                                            ^^^^^^^^^^^^^^^^^^

error(missing-item): discrimination trait tradition_feminist not defined in common/discrimination_traits/
  --> [MOD] common\scripted_effects\zzz_converter_effects_gender.txt
83 |             any_primary_culture = { has_discrimination_trait = tradition_feminist }
   |                                                                ^^^^^^^^^^^^^^^^^^

error(missing-item): discrimination trait tradition_feminist not defined in common/discrimination_traits/
   --> [MOD] common\scripted_effects\zzz_converter_effects_gender.txt
153 |                 has_discrimination_trait = tradition_feminist
    |                                            ^^^^^^^^^^^^^^^^^^

error(missing-item): discrimination trait tradition_feminist not defined in common/discrimination_traits/
   --> [MOD] common\scripted_effects\zzz_converter_effects_gender.txt
176 |                 has_discrimination_trait = tradition_feminist
    |                                            ^^^^^^^^^^^^^^^^^^

error(missing-item): discrimination trait tradition_feminist not defined in common/discrimination_traits/
   --> [MOD] common\scripted_effects\zzz_converter_effects_gender.txt
189 |             NOT = { any_primary_culture = { has_discrimination_trait = tradition_feminist } }
    |                                                                        ^^^^^^^^^^^^^^^^^^

error(missing-item): discrimination trait tradition_feminist not defined in common/discrimination_traits/
   --> [MOD] common\scripted_effects\zzz_converter_effects_gender.txt
198 |             any_primary_culture = { has_discrimination_trait = tradition_feminist }
    |                                                                ^^^^^^^^^^^^^^^^^^

error(missing-item): discrimination trait tradition_egalitarian not defined in common/discrimination_traits/
    --> [MOD] common\scripted_effects\zzz_converter_effects_new.txt
1275 |                 has_discrimination_trait = tradition_egalitarian
     |                                            ^^^^^^^^^^^^^^^^^^^^^ 

error(missing-item): discrimination trait tradition_egalitarian not defined in common/discrimination_traits/
    --> [MOD] common\scripted_effects\zzz_converter_effects_new.txt
1284 |                 any_primary_culture = { has_discrimination_trait = tradition_egalitarian }
     |                                                                    ^^^^^^^^^^^^^^^^^^^^^ 
```